### PR TITLE
feat: Match regexp no match to Spark

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/sort/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/sort/mod.rs
@@ -229,10 +229,9 @@ where
     }
 }
 
-impl<'a> Into<Ordering> for AnyValue<'_> {
-    #[inline]
-    fn into(self) -> Ordering {
-        match self {
+impl From<AnyValue<'_>> for Ordering {
+    fn from(value: AnyValue) -> Self {
+        match value {
             AnyValue::Int8(val) => if val == 1 {
                 Ordering::Greater
             } else if val == -1 {
@@ -854,7 +853,7 @@ impl ChunkSort<BooleanType> for BooleanChunked {
             }
 
             self.downcast_iter().for_each(|arr| {
-                let iter = arr.iter().filter_map(|v| v);
+                let iter = arr.iter().flatten();
                 vals.extend(iter);
             });
             let mut_slice = if options.nulls_last {

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -84,11 +84,10 @@ fn extract_group_reg_lit(
         if let Some(s) = opt_v {
             if reg.captures_read(&mut locs, s).is_some() {
                 builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
-                continue;
             } else {
                 builder.push(Some(""));
-                continue;
             }
+            continue;
         }
 
         // Push null if either the string is null or there was no match.
@@ -140,10 +139,9 @@ fn extract_group_binary(
                 if reg.captures_read(&mut locs, s).is_some() {
                     builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
                     continue;
-                } else {
-                    builder.push(Some(""));
-                    continue;
                 }
+                
+                builder.push(Some(""));
             },
             _ => builder.push_null(),
         }

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -85,6 +85,9 @@ fn extract_group_reg_lit(
             if reg.captures_read(&mut locs, s).is_some() {
                 builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
                 continue;
+            } else {
+                builder.push(Some(""));
+                continue;
             }
         }
 
@@ -110,6 +113,9 @@ fn extract_group_array_lit(
                 builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
                 continue;
             }
+        } else {
+            builder.push(Some(""));
+            continue;
         }
 
         // Push null if either the pat is null or there was no match.
@@ -134,9 +140,10 @@ fn extract_group_binary(
                 if reg.captures_read(&mut locs, s).is_some() {
                     builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
                     continue;
+                } else {
+                    builder.push(Some(""));
+                    continue;
                 }
-                // Push null if there was no match.
-                builder.push_null()
             },
             _ => builder.push_null(),
         }


### PR DESCRIPTION
Upon no match, we should be returning an empty string instead of a None