### PR TITLE
feat: Implement binary concat, add more primitives to lambda

### DIFF
--- a/crates/polars-arrow/src/legacy/utils.rs
+++ b/crates/polars-arrow/src/legacy/utils.rs
@@ -1,4 +1,5 @@
 use polars_error::PolarsResult;
+
 use crate::array::PrimitiveArray;
 use crate::bitmap::utils::set_bit_unchecked;
 use crate::bitmap::MutableBitmap;

--- a/crates/polars-arrow/src/legacy/utils.rs
+++ b/crates/polars-arrow/src/legacy/utils.rs
@@ -1,3 +1,4 @@
+use polars_error::PolarsResult;
 use crate::array::PrimitiveArray;
 use crate::bitmap::utils::set_bit_unchecked;
 use crate::bitmap::MutableBitmap;
@@ -74,6 +75,30 @@ impl<T: NativeType> FromTrustedLenIterator<T> for PrimitiveArray<T> {
     {
         let iter = iter.into_iter();
         unsafe { PrimitiveArray::from_trusted_len_values_iter_unchecked(iter) }
+    }
+}
+
+// FLARION: This allows for efficient collection of PolarsResult<T> where T would normally support FromTrustedLenIterator
+impl<T, A> FromTrustedLenIterator<PolarsResult<A>> for PolarsResult<T>
+where
+    T: FromTrustedLenIterator<A>,
+{
+    fn from_iter_trusted_length<I: IntoIterator<Item = PolarsResult<A>>>(iter: I) -> Self
+    where
+        I::IntoIter: TrustedLen,
+    {
+        // First collect any errors that might occur
+        let iter = iter.into_iter();
+        let (ok_values, errors): (Vec<_>, Vec<_>) = iter.partition(Result::is_ok);
+
+        // If we found any errors, return the first one
+        if let Some(err) = errors.into_iter().next() {
+            return err.map(|_| unreachable!());
+        }
+
+        // Unwrap the Ok values and collect into the inner type
+        let ok_iter = ok_values.into_iter().map(Result::unwrap);
+        Ok(T::from_iter_trusted_length(ok_iter))
     }
 }
 

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
+
 use num_traits::ToBytes;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
@@ -52,36 +53,34 @@ impl Hash for LambdaExpression {
             LambdaExpression::GreaterThan(first, second) => {
                 first.hash(state);
                 second.hash(state);
-            }
+            },
             LambdaExpression::LessThan(first, second) => {
                 first.hash(state);
                 second.hash(state);
-            }
+            },
             LambdaExpression::IfThenElse(first, second, third) => {
                 first.hash(state);
                 second.hash(state);
                 third.hash(state);
-            }
-            LambdaExpression::Length(v) => {
-                v.hash(state)
-            }
+            },
+            LambdaExpression::Length(v) => v.hash(state),
             LambdaExpression::CaseWhen(first, second) => {
                 first.hash(state);
                 second.hash(state);
-            }
+            },
             LambdaExpression::Substring(first, second, third) => {
                 first.hash(state);
                 second.hash(state);
                 third.hash(state);
-            }
+            },
             LambdaExpression::Instr(first, second) => {
                 first.hash(state);
                 second.hash(state);
-            }
+            },
             LambdaExpression::Add(first, second) => {
                 first.hash(state);
                 second.hash(state);
-            }
+            },
         }
     }
 }
@@ -94,26 +93,26 @@ fn substring<'a>(s: AnyValue<'a>, from: AnyValue<'a>, len: Option<AnyValue<'a>>)
                 let to = (from + len as usize).min(s.len());
                 let result = &s[from..to];
                 AnyValue::String(result)
-            }
+            },
             (AnyValue::String(s), AnyValue::Int32(from), None) => {
                 let from = from as usize - 1;
                 let to = s.len();
                 let result = &s[from..to];
                 AnyValue::String(result)
-            }
+            },
             (AnyValue::Binary(bin), AnyValue::Int32(from), Some(AnyValue::Int32(len))) => {
                 let from = from as usize - 1;
                 let to = (from + len as usize).min(bin.len());
                 let result = &bin[from..to];
                 AnyValue::Binary(result)
-            }
+            },
 
             (AnyValue::Binary(bin), AnyValue::Int32(from), None) => {
                 let from = from as usize - 1;
                 let to = bin.len();
                 let result = &bin[from..to];
                 AnyValue::Binary(result)
-            }
+            },
             _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
         }
     }
@@ -174,13 +173,15 @@ impl LambdaExpression {
                     }
                 }
                 otherwise.eval_array(args)
-            }
+            },
             LambdaExpression::Substring(s, from, len) => {
                 let s = s.eval_array(args);
                 let from = from.eval_array(args).cast(&DataType::Int32);
-                let len = len.as_ref().map(|v| v.eval_array(args).cast(&DataType::Int32));
+                let len = len
+                    .as_ref()
+                    .map(|v| v.eval_array(args).cast(&DataType::Int32));
                 substring(s, from, len)
-            }
+            },
             LambdaExpression::Instr(s, pat) => {
                 let s = s.eval_array(args);
                 let pat = pat.eval_array(args);
@@ -188,7 +189,7 @@ impl LambdaExpression {
                     match (s, pat) {
                         (AnyValue::String(s), AnyValue::String(pat)) => {
                             AnyValue::Int32(s.find(pat).map(|x| x + 1).unwrap_or(0) as i32)
-                        }
+                        },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }
                 }
@@ -249,14 +250,15 @@ impl LambdaExpression {
                     }
                 }
                 otherwise.eval_numeric::<T>(args)
-            }
+            },
             LambdaExpression::Substring(s, from, len) => {
                 let s = s.eval_numeric::<T>(args);
                 let from = from.eval_numeric::<T>(args).cast(&DataType::Int32);
-                let len = len.as_ref().map(|v| v.eval_numeric::<T>(args).cast(&DataType::Int32));
+                let len = len
+                    .as_ref()
+                    .map(|v| v.eval_numeric::<T>(args).cast(&DataType::Int32));
                 substring(s, from, len)
-            
-            }
+            },
             LambdaExpression::Instr(s, pat) => {
                 let s = s.eval_numeric::<T>(args);
                 let pat = pat.eval_numeric::<T>(args);
@@ -264,17 +266,16 @@ impl LambdaExpression {
                     match (s, pat) {
                         (AnyValue::String(s), AnyValue::String(pat)) => {
                             AnyValue::Int32(s.find(pat).map(|x| x + 1).unwrap_or(0) as i32)
-                        }
+                        },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }
                 }
-            }
+            },
             LambdaExpression::Add(left, right) => {
                 let left = left.eval_numeric::<T>(args);
                 let right = right.eval_numeric::<T>(args);
                 left.add(&right.cast(&left.dtype()))
-            }
-            
+            },
         }
     }
 
@@ -330,7 +331,9 @@ impl LambdaExpression {
             LambdaExpression::Substring(s, from, len) => {
                 let s = s.eval_bool(args);
                 let from = from.eval_bool(args).cast(&DataType::Int32);
-                let len = len.as_ref().map(|v| v.eval_bool(args).cast(&DataType::Int32));
+                let len = len
+                    .as_ref()
+                    .map(|v| v.eval_bool(args).cast(&DataType::Int32));
                 substring(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
@@ -340,7 +343,7 @@ impl LambdaExpression {
                     match (s, pat) {
                         (AnyValue::String(s), AnyValue::String(pat)) => {
                             AnyValue::Int32(s.find(pat).map(|x| x + 1).unwrap_or(0) as i32)
-                        }
+                        },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }
                 }
@@ -350,7 +353,6 @@ impl LambdaExpression {
                 let right = right.eval_bool(args);
                 left.add(&right.cast(&left.dtype()))
             },
-            
         }
     }
 
@@ -409,7 +411,9 @@ impl LambdaExpression {
             LambdaExpression::Substring(s, from, len) => {
                 let s = s.eval_slice(args);
                 let from = from.eval_slice(args).cast(&DataType::Int32);
-                let len = len.as_ref().map(|v| v.eval_slice(args).cast(&DataType::Int32));
+                let len = len
+                    .as_ref()
+                    .map(|v| v.eval_slice(args).cast(&DataType::Int32));
                 substring(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
@@ -419,7 +423,7 @@ impl LambdaExpression {
                     match (s, pat) {
                         (AnyValue::String(s), AnyValue::String(pat)) => {
                             AnyValue::Int32(s.find(pat).map(|x| x + 1).unwrap_or(0) as i32)
-                        }
+                        },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }
                 }
@@ -429,10 +433,8 @@ impl LambdaExpression {
                 let right = right.eval_slice(args);
                 left.add(&right.cast(&left.dtype()))
             },
-            
         }
     }
-
 
     pub(crate) fn eval_any<'a>(&'a self, args: &[AnyValue<'a>]) -> AnyValue<'a> {
         match self {
@@ -488,7 +490,9 @@ impl LambdaExpression {
             LambdaExpression::Substring(s, from, len) => {
                 let s = s.eval_any(args);
                 let from = from.eval_any(args).cast(&DataType::Int32);
-                let len = len.as_ref().map(|v| v.eval_any(args).cast(&DataType::Int32));
+                let len = len
+                    .as_ref()
+                    .map(|v| v.eval_any(args).cast(&DataType::Int32));
                 substring(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
@@ -498,7 +502,7 @@ impl LambdaExpression {
                     match (s, pat) {
                         (AnyValue::String(s), AnyValue::String(pat)) => {
                             AnyValue::Int32(s.find(pat).map(|x| x + 1).unwrap_or(0) as i32)
-                        }
+                        },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }
                 }
@@ -529,22 +533,19 @@ impl LambdaExpression {
             LambdaExpression::LessThan(_, _) => Some(DataType::Boolean),
             LambdaExpression::IfThenElse(_, then, _) => then.return_type(),
             LambdaExpression::Length(_) => Some(DataType::Int32),
-            LambdaExpression::CaseWhen(cases, _) => {
-                cases
-                    .iter()
-                    .find_map(|pair| {
-                        if let Some(dtype) = pair.1.return_type() {
-                            dtype.is_null().then_some(dtype).map(Some)
-                        } else {
-                            Some(None)
-                        }
-                    })
-                    .unwrap_or(Some(DataType::Null))
-            }
+            LambdaExpression::CaseWhen(cases, _) => cases
+                .iter()
+                .find_map(|pair| {
+                    if let Some(dtype) = pair.1.return_type() {
+                        dtype.is_null().then_some(dtype).map(Some)
+                    } else {
+                        Some(None)
+                    }
+                })
+                .unwrap_or(Some(DataType::Null)),
             LambdaExpression::Substring(s, _, _) => s.return_type(), // substring is used for string and byte arrays
             LambdaExpression::Instr(_, _) => Some(DataType::Int32),
             LambdaExpression::Add(left, _) => left.return_type(),
-            
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -33,6 +33,8 @@ pub enum LambdaExpression {
     Add(Box<Self>, Box<Self>),
 }
 
+impl Eq for LambdaExpression {}
+
 impl Hash for LambdaExpression {
     fn hash<H: Hasher>(&self, state: &mut H) {
         match self {

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 
-use polars_utils::nulls::IsNull;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
 

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
-
+use std::hash::{Hash, Hasher};
+use num_traits::ToBytes;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
 
@@ -8,13 +9,18 @@ use crate::datatypes::{AnyValue, PolarsNumericType};
 use crate::prelude::Array;
 use crate::series::Series;
 
-#[derive(Clone, Eq, PartialEq, Debug, Hash)]
+#[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
 pub enum LambdaExpression {
     Null,
     Boolean(bool),
+    Int8(i8),
+    Int16(i16),
     Int32(i32),
     Int64(i64),
+    Float32(f32),
+    Float64(f64),
+    BinaryBlob(Vec<u8>),
     StaticStr(Cow<'static, str>),
     Variable(usize),
     GreaterThan(Box<Self>, Box<Self>),
@@ -25,6 +31,57 @@ pub enum LambdaExpression {
     Substring(Box<Self>, Box<Self>, Option<Box<Self>>),
     Instr(Box<Self>, Box<Self>),
     Add(Box<Self>, Box<Self>),
+}
+
+impl Hash for LambdaExpression {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            LambdaExpression::Null => 0.hash(state),
+            LambdaExpression::Boolean(v) => v.hash(state),
+            LambdaExpression::Int8(v) => v.hash(state),
+            LambdaExpression::Int16(v) => v.hash(state),
+            LambdaExpression::Int32(v) => v.hash(state),
+            LambdaExpression::Int64(v) => v.hash(state),
+            LambdaExpression::Float32(v) => v.to_le_bytes().hash(state),
+            LambdaExpression::Float64(v) => v.to_le_bytes().hash(state),
+            LambdaExpression::BinaryBlob(v) => v.hash(state),
+            LambdaExpression::StaticStr(v) => v.hash(state),
+            LambdaExpression::Variable(v) => v.hash(state),
+            LambdaExpression::GreaterThan(first, second) => {
+                first.hash(state);
+                second.hash(state);
+            }
+            LambdaExpression::LessThan(first, second) => {
+                first.hash(state);
+                second.hash(state);
+            }
+            LambdaExpression::IfThenElse(first, second, third) => {
+                first.hash(state);
+                second.hash(state);
+                third.hash(state);
+            }
+            LambdaExpression::Length(v) => {
+                v.hash(state)
+            }
+            LambdaExpression::CaseWhen(first, second) => {
+                first.hash(state);
+                second.hash(state);
+            }
+            LambdaExpression::Substring(first, second, third) => {
+                first.hash(state);
+                second.hash(state);
+                third.hash(state);
+            }
+            LambdaExpression::Instr(first, second) => {
+                first.hash(state);
+                second.hash(state);
+            }
+            LambdaExpression::Add(first, second) => {
+                first.hash(state);
+                second.hash(state);
+            }
+        }
+    }
 }
 
 fn substring<'a>(s: AnyValue<'a>, from: AnyValue<'a>, len: Option<AnyValue<'a>>) -> AnyValue<'a> {
@@ -66,8 +123,13 @@ impl LambdaExpression {
         match self {
             LambdaExpression::Null => AnyValue::Null,
             LambdaExpression::Boolean(v) => AnyValue::Boolean(*v),
+            LambdaExpression::Int8(v) => AnyValue::Int8(*v),
+            LambdaExpression::Int16(v) => AnyValue::Int16(*v),
             LambdaExpression::Int32(v) => AnyValue::Int32(*v),
             LambdaExpression::Int64(v) => AnyValue::Int64(*v),
+            LambdaExpression::Float32(v) => AnyValue::Float32(*v),
+            LambdaExpression::Float64(v) => AnyValue::Float64(*v),
+            LambdaExpression::BinaryBlob(v) => AnyValue::Binary(v),
             LambdaExpression::StaticStr(v) => AnyValue::String(v),
             LambdaExpression::Variable(idx) => {
                 let arr = args[*idx];
@@ -142,8 +204,13 @@ impl LambdaExpression {
         match self {
             LambdaExpression::Null => AnyValue::Null,
             LambdaExpression::Boolean(v) => AnyValue::Boolean(*v),
+            LambdaExpression::Int8(v) => AnyValue::Int8(*v),
+            LambdaExpression::Int16(v) => AnyValue::Int16(*v),
             LambdaExpression::Int32(v) => AnyValue::Int32(*v),
             LambdaExpression::Int64(v) => AnyValue::Int64(*v),
+            LambdaExpression::Float32(v) => AnyValue::Float32(*v),
+            LambdaExpression::Float64(v) => AnyValue::Float64(*v),
+            LambdaExpression::BinaryBlob(v) => AnyValue::Binary(v),
             LambdaExpression::StaticStr(v) => AnyValue::String(v),
             LambdaExpression::Variable(idx) => (*args[*idx]).into(),
             LambdaExpression::GreaterThan(left, right) => {
@@ -214,8 +281,13 @@ impl LambdaExpression {
         match self {
             LambdaExpression::Null => AnyValue::Null,
             LambdaExpression::Boolean(v) => AnyValue::Boolean(*v),
+            LambdaExpression::Int8(v) => AnyValue::Int8(*v),
+            LambdaExpression::Int16(v) => AnyValue::Int16(*v),
             LambdaExpression::Int32(v) => AnyValue::Int32(*v),
             LambdaExpression::Int64(v) => AnyValue::Int64(*v),
+            LambdaExpression::Float32(v) => AnyValue::Float32(*v),
+            LambdaExpression::Float64(v) => AnyValue::Float64(*v),
+            LambdaExpression::BinaryBlob(v) => AnyValue::Binary(v),
             LambdaExpression::StaticStr(v) => AnyValue::String(v),
             LambdaExpression::Variable(idx) => (*args[*idx]).into(),
             LambdaExpression::GreaterThan(left, right) => {
@@ -285,8 +357,13 @@ impl LambdaExpression {
         match self {
             LambdaExpression::Null => AnyValue::Null,
             LambdaExpression::Boolean(v) => AnyValue::Boolean(*v),
+            LambdaExpression::Int8(v) => AnyValue::Int8(*v),
+            LambdaExpression::Int16(v) => AnyValue::Int16(*v),
             LambdaExpression::Int32(v) => AnyValue::Int32(*v),
             LambdaExpression::Int64(v) => AnyValue::Int64(*v),
+            LambdaExpression::Float32(v) => AnyValue::Float32(*v),
+            LambdaExpression::Float64(v) => AnyValue::Float64(*v),
+            LambdaExpression::BinaryBlob(v) => AnyValue::Binary(v),
             LambdaExpression::StaticStr(v) => AnyValue::String(v),
             LambdaExpression::Variable(idx) => AnyValue::Binary(args[*idx]),
             LambdaExpression::GreaterThan(left, right) => {
@@ -359,8 +436,13 @@ impl LambdaExpression {
         match self {
             LambdaExpression::Null => AnyValue::Null,
             LambdaExpression::Boolean(v) => AnyValue::Boolean(*v),
+            LambdaExpression::Int8(v) => AnyValue::Int8(*v),
+            LambdaExpression::Int16(v) => AnyValue::Int16(*v),
             LambdaExpression::Int32(v) => AnyValue::Int32(*v),
             LambdaExpression::Int64(v) => AnyValue::Int64(*v),
+            LambdaExpression::Float32(v) => AnyValue::Float32(*v),
+            LambdaExpression::Float64(v) => AnyValue::Float64(*v),
+            LambdaExpression::BinaryBlob(v) => AnyValue::Binary(v),
             LambdaExpression::StaticStr(v) => AnyValue::String(v),
             LambdaExpression::Variable(idx) => args[*idx].clone(),
             LambdaExpression::GreaterThan(left, right) => {
@@ -432,8 +514,13 @@ impl LambdaExpression {
         match self {
             LambdaExpression::Null => Some(DataType::Null),
             LambdaExpression::Boolean(_) => Some(DataType::Boolean),
+            LambdaExpression::Int8(_) => Some(DataType::Int8),
+            LambdaExpression::Int16(_) => Some(DataType::Int16),
             LambdaExpression::Int32(_) => Some(DataType::Int32),
             LambdaExpression::Int64(_) => Some(DataType::Int64),
+            LambdaExpression::Float32(_) => Some(DataType::Float32),
+            LambdaExpression::Float64(_) => Some(DataType::Float64),
+            LambdaExpression::BinaryBlob(_) => Some(DataType::Binary),
             LambdaExpression::StaticStr(_) => Some(DataType::String),
             LambdaExpression::Variable(_) => None,
             LambdaExpression::GreaterThan(_, _) => Some(DataType::Boolean),

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -453,7 +453,6 @@ pub trait ChunkReverse {
     fn reverse(&self) -> Self;
 }
 
-
 pub trait ChunkTransform {
     fn transform(&self, lambda: &super::LambdaExpression) -> polars_error::PolarsResult<Series>;
 }

--- a/crates/polars-core/src/chunked_array/ops/transform.rs
+++ b/crates/polars-core/src/chunked_array/ops/transform.rs
@@ -1,7 +1,9 @@
-
 use arrow::array::Array;
 
-use super::{BinaryChunked, BooleanChunked, ChunkTransform, ChunkedArray, ListChunked, PolarsNumericType, SeriesTrait, StringChunked};
+use super::{
+    BinaryChunked, BooleanChunked, ChunkTransform, ChunkedArray, ListChunked, PolarsNumericType,
+    SeriesTrait, StringChunked,
+};
 use crate::prelude::AnyValue;
 use crate::series::implementations::SeriesWrap;
 use crate::series::{IntoSeries, Series};
@@ -21,13 +23,14 @@ where
         let vec: Vec<AnyValue> = self
             .iter()
             .enumerate()
-            .map(|(i, value): (usize, Option<T::Native>)| lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)]))
+            .map(|(i, value): (usize, Option<T::Native>)| {
+                lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)])
+            })
             .collect();
 
         Series::from_any_values("".into(), &vec, true)
     }
 }
-
 
 impl ChunkTransform for StringChunked {
     fn transform(&self, lambda: &super::LambdaExpression) -> polars_error::PolarsResult<Series> {
@@ -46,7 +49,10 @@ impl ChunkTransform for StringChunked {
 }
 
 impl ChunkTransform for BinaryChunked {
-    fn transform(&self, lambda: &crate::chunked_array::LambdaExpression) -> polars_error::PolarsResult<Series> {
+    fn transform(
+        &self,
+        lambda: &crate::chunked_array::LambdaExpression,
+    ) -> polars_error::PolarsResult<Series> {
         if self.is_empty() {
             return Ok(self.clone().into_series());
         }
@@ -64,8 +70,8 @@ impl ChunkTransform for BinaryChunked {
 fn array_to_any(value: Option<Box<dyn Array>>) -> AnyValue<'static> {
     match value {
         Some(value) => {
-            let series = Series::from_arrow("".into(), value)
-                .expect("could not convert array to series");
+            let series =
+                Series::from_arrow("".into(), value).expect("could not convert array to series");
             AnyValue::List(series)
         },
         None => AnyValue::Null,
@@ -73,7 +79,10 @@ fn array_to_any(value: Option<Box<dyn Array>>) -> AnyValue<'static> {
 }
 
 impl ChunkTransform for ListChunked {
-    fn transform(&self, lambda: &crate::chunked_array::LambdaExpression) -> polars_error::PolarsResult<Series> {
+    fn transform(
+        &self,
+        lambda: &crate::chunked_array::LambdaExpression,
+    ) -> polars_error::PolarsResult<Series> {
         if self.is_empty() {
             return Ok(self.clone().into_series());
         }
@@ -88,9 +97,11 @@ impl ChunkTransform for ListChunked {
     }
 }
 
-
 impl ChunkTransform for BooleanChunked {
-    fn transform(&self, lambda: &crate::chunked_array::LambdaExpression) -> polars_error::PolarsResult<Series> {
+    fn transform(
+        &self,
+        lambda: &crate::chunked_array::LambdaExpression,
+    ) -> polars_error::PolarsResult<Series> {
         if self.is_empty() {
             return Ok(self.clone().into_series());
         }

--- a/crates/polars-core/src/series/implementations/binary.rs
+++ b/crates/polars-core/src/series/implementations/binary.rs
@@ -252,30 +252,39 @@ impl SeriesTrait for SeriesWrap<BinaryChunked> {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use crate::series::{BinaryChunked, IntoSeries, LambdaExpression, NamedFrom};
-
 
     #[test]
     fn test_transform_bin() {
         // we check that there is correct implementation for StringChunked inside series
         // also we check that length returning Int32 type
-        let series = BinaryChunked::new("array".into(), &[b"Hi!" as &[u8], b"I'm" as &[u8], b"Yan" as &[u8]]).into_series();
+        let series = BinaryChunked::new(
+            "array".into(),
+            &[b"Hi!" as &[u8], b"I'm" as &[u8], b"Yan" as &[u8]],
+        )
+        .into_series();
 
         let lambda = LambdaExpression::Variable(0);
 
         let transformed = series.transform(&lambda);
 
         assert!(matches!(transformed, Ok(_)));
-        
+
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
         let result = transformed.binary();
 
         assert!(matches!(result, Ok(_)));
 
-        assert_eq!(Vec::from(result.unwrap()), vec![Some(b"Hi!" as &[u8]), Some(b"I'm" as &[u8]), Some(b"Yan" as &[u8])]);
+        assert_eq!(
+            Vec::from(result.unwrap()),
+            vec![
+                Some(b"Hi!" as &[u8]),
+                Some(b"I'm" as &[u8]),
+                Some(b"Yan" as &[u8])
+            ]
+        );
     }
 }

--- a/crates/polars-core/src/series/implementations/boolean.rs
+++ b/crates/polars-core/src/series/implementations/boolean.rs
@@ -318,7 +318,6 @@ impl SeriesTrait for SeriesWrap<BooleanChunked> {
 
 #[cfg(test)]
 mod tests {
-    
 
     use crate::series::{BooleanChunked, IntoSeries, LambdaExpression, NamedFrom};
 
@@ -327,12 +326,16 @@ mod tests {
         // here we test that transform is defined on series with booleanchunked array
         let series = BooleanChunked::new("array".into(), &vec![true, false, true]).into_series();
 
-        let lambda = LambdaExpression::IfThenElse(Box::new(LambdaExpression::Variable(0)), Box::new(LambdaExpression::Int32(1)), Box::new(LambdaExpression::Int32(0)));
+        let lambda = LambdaExpression::IfThenElse(
+            Box::new(LambdaExpression::Variable(0)),
+            Box::new(LambdaExpression::Int32(1)),
+            Box::new(LambdaExpression::Int32(0)),
+        );
 
         let transformed = series.transform(&lambda);
 
         assert!(matches!(transformed, Ok(_)));
-        
+
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
         let result = transformed.i32();

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -375,7 +375,6 @@ macro_rules! impl_dyn_series {
 impl_dyn_series!(Float32Chunked);
 impl_dyn_series!(Float64Chunked);
 
-
 #[cfg(test)]
 mod tests {
     use crate::series::{ChunkedArray, Float32Type, IntoSeries, LambdaExpression};
@@ -384,20 +383,27 @@ mod tests {
     fn test_transform_float() {
         // here we test integer conversion
         // and thats we implemented transform on integer types
-        let series = ChunkedArray::<Float32Type>::from_vec("array".into(), vec![0.1, 0.2, 0.3]).into_series();
+        let series = ChunkedArray::<Float32Type>::from_vec("array".into(), vec![0.1, 0.2, 0.3])
+            .into_series();
 
-        let lambda = LambdaExpression::Add(Box::new(LambdaExpression::Variable(0)), Box::new(LambdaExpression::Int64(1)));
+        let lambda = LambdaExpression::Add(
+            Box::new(LambdaExpression::Variable(0)),
+            Box::new(LambdaExpression::Int64(1)),
+        );
 
         let transformed = series.transform(&lambda);
 
         assert!(matches!(transformed, Ok(_)));
-        
+
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
         let result = transformed.f32();
 
         assert!(matches!(result, Ok(_)));
 
-        assert_eq!(Vec::from(result.unwrap()), vec![Some(1.1), Some(1.2), Some(1.3)]);
+        assert_eq!(
+            Vec::from(result.unwrap()),
+            vec![Some(1.1), Some(1.2), Some(1.3)]
+        );
     }
 }

--- a/crates/polars-core/src/series/implementations/list.rs
+++ b/crates/polars-core/src/series/implementations/list.rs
@@ -248,23 +248,28 @@ mod tests {
         let arr2 = row2.clone().downcast_into_array();
         let arr3 = row3.clone().downcast_into_array();
         let series = ListChunked::from_iter(vec![
-            row1.into_series(), 
-            row2.into_series(), 
-            row3.into_series(), 
-        ]).into_series();
+            row1.into_series(),
+            row2.into_series(),
+            row3.into_series(),
+        ])
+        .into_series();
 
         let lambda = LambdaExpression::Variable(0); // There is no functions that work on arrays
 
         let transformed = series.transform(&lambda);
-        
+
         assert!(matches!(transformed, Ok(_)));
-        
+
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
         let result = transformed.list();
 
         assert!(matches!(result, Ok(_)));
-        let vec: Vec<Option<Box<dyn Array>>> = vec![Some(Box::new(arr1)), Some(Box::new(arr2)), Some(Box::new(arr3))];
+        let vec: Vec<Option<Box<dyn Array>>> = vec![
+            Some(Box::new(arr1)),
+            Some(Box::new(arr2)),
+            Some(Box::new(arr3)),
+        ];
         assert_eq!(Vec::from(result.unwrap()), vec);
     }
 }

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -547,7 +547,6 @@ impl private::PrivateSeriesNumeric for SeriesWrap<BooleanChunked> {
     }
 }
 
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -556,14 +555,18 @@ mod tests {
     fn test_transform_numeric_conversion() {
         // here we test integer conversion
         // and thats we implemented transform on integer types
-        let series = ChunkedArray::<Int32Type>::from_vec("array".into(), vec![1, 2, 3]).into_series();
+        let series =
+            ChunkedArray::<Int32Type>::from_vec("array".into(), vec![1, 2, 3]).into_series();
 
-        let lambda = LambdaExpression::Add(Box::new(LambdaExpression::Variable(0)), Box::new(LambdaExpression::Int64(1)));
+        let lambda = LambdaExpression::Add(
+            Box::new(LambdaExpression::Variable(0)),
+            Box::new(LambdaExpression::Int64(1)),
+        );
 
         let transformed = series.transform(&lambda);
 
         assert!(matches!(transformed, Ok(_)));
-        
+
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
         let result = transformed.i32();
@@ -573,28 +576,33 @@ mod tests {
         assert_eq!(Vec::from(result.unwrap()), vec![Some(2), Some(3), Some(4)]);
     }
 
-
     #[test]
     fn test_transform_numeric_different_type() {
         // here we test that lambda can return complitly different type
-        let series = ChunkedArray::<Int32Type>::from_vec("array".into(), vec![1, 2, 3]).into_series();
+        let series =
+            ChunkedArray::<Int32Type>::from_vec("array".into(), vec![1, 2, 3]).into_series();
 
         let lambda = LambdaExpression::StaticStr("hello world".into());
 
         let transformed = series.transform(&lambda);
 
         assert!(matches!(transformed, Ok(_)));
-        
+
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
         let result = transformed.str();
 
         assert!(matches!(result, Ok(_)));
 
-        assert_eq!(Vec::from(result.unwrap()), vec![Some("hello world"), Some("hello world"), Some("hello world")]);
-
+        assert_eq!(
+            Vec::from(result.unwrap()),
+            vec![
+                Some("hello world"),
+                Some("hello world"),
+                Some("hello world")
+            ]
+        );
     }
-
 
     #[test]
     fn test_transform_numeric_nulls() {
@@ -606,14 +614,18 @@ mod tests {
             builder.append_null();
             builder.append_value(3);
             builder.finish()
-        }.into_series();
+        }
+        .into_series();
 
-        let lambda = LambdaExpression::Add(Box::new(LambdaExpression::Variable(0)), Box::new(LambdaExpression::Int64(1)));
+        let lambda = LambdaExpression::Add(
+            Box::new(LambdaExpression::Variable(0)),
+            Box::new(LambdaExpression::Int64(1)),
+        );
 
         let transformed = series.transform(&lambda);
 
         assert!(matches!(transformed, Ok(_)));
-        
+
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
         let result = transformed.i32();
@@ -626,15 +638,18 @@ mod tests {
     #[test]
     fn test_transform_numberic_second_parameter() {
         // here we test that lambda gets index as second parameter
-        let series = ChunkedArray::<Int32Type>::from_vec("array".into(), vec![0, 0, 0]).into_series();
+        let series =
+            ChunkedArray::<Int32Type>::from_vec("array".into(), vec![0, 0, 0]).into_series();
 
-
-        let lambda = LambdaExpression::Add(Box::new(LambdaExpression::Variable(1)), Box::new(LambdaExpression::Int64(1)));
+        let lambda = LambdaExpression::Add(
+            Box::new(LambdaExpression::Variable(1)),
+            Box::new(LambdaExpression::Int64(1)),
+        );
 
         let transformed = series.transform(&lambda);
 
         assert!(matches!(transformed, Ok(_)));
-        
+
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
         let result = transformed.i32();

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -275,12 +275,15 @@ mod tests {
         // also we check that length returning Int32 type
         let series = StringChunked::new("array".into(), &["Hi!", "I'm", "Mark"]).into_series();
 
-        let lambda = LambdaExpression::Instr(Box::new(LambdaExpression::Variable(0)), Box::new(LambdaExpression::StaticStr("H".into())));
+        let lambda = LambdaExpression::Instr(
+            Box::new(LambdaExpression::Variable(0)),
+            Box::new(LambdaExpression::StaticStr("H".into())),
+        );
 
         let transformed = series.transform(&lambda);
 
         assert!(matches!(transformed, Ok(_)));
-        
+
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
         let result = transformed.i32();
@@ -288,6 +291,5 @@ mod tests {
         assert!(matches!(result, Ok(_)));
 
         assert_eq!(Vec::from(result.unwrap()), vec![Some(1), Some(0), Some(0)]);
-
     }
 }

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -75,8 +75,12 @@ fn cast_rhs(
     Ok(())
 }
 
-pub fn list_flarion_slice_amortized(s: AmortSeries, offset: i64, length: i64) -> Series {
-    if offset > 0 && offset < s.as_ref().len() as i64 {
+pub fn list_flarion_slice_amortized(s: AmortSeries, mut offset: i64, length: i64) -> Series {
+    let element_len = s.as_ref().len() as i64;
+    if offset < 0 {
+        offset += element_len;
+    }
+    if (0..element_len).contains(&offset) {
         s.as_ref().slice(offset, length as usize)
     } else {
         Series::new_empty(s.as_ref().name().clone(), s.as_ref().dtype())

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -7,6 +7,7 @@ use polars_core::chunked_array::builder::get_list_builder;
 use polars_core::export::num::ToPrimitive;
 #[cfg(feature = "list_gather")]
 use polars_core::export::num::{NumCast, Signed, Zero};
+use polars_core::series::amortized_iter::AmortSeries;
 #[cfg(feature = "diff")]
 use polars_core::series::ops::NullBehavior;
 use polars_core::utils::try_get_supertype;
@@ -72,6 +73,14 @@ fn cast_rhs(
         }
     }
     Ok(())
+}
+
+pub fn list_flarion_slice_amortized(s: AmortSeries, offset: i64, length: i64) -> Series {
+    if offset > 0 && offset < s.as_ref().len() as i64 {
+        s.as_ref().slice(offset, length as usize)
+    } else {
+        Series::new_empty(s.as_ref().name().clone(), s.as_ref().dtype())
+    }
 }
 
 pub trait ListNameSpaceImpl: AsList {
@@ -360,6 +369,14 @@ pub trait ListNameSpaceImpl: AsList {
             }),
         };
         Ok(self.same_type(out))
+    }
+
+    fn lst_flarion_slice(&self, (offset, length): (i64, i64)) -> ListChunked {
+        let ca = self.as_list();
+        let out = ca.apply_amortized(|s| {
+            list_flarion_slice_amortized(s, offset, length)
+        });
+        self.same_type(out)
     }
 
     fn lst_slice(&self, offset: i64, length: usize) -> ListChunked {

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -282,10 +282,10 @@ pub trait ListNameSpaceImpl: AsList {
 
     fn lst_transform(
         &self,
-        lambda_expressions: Arc<LambdaExpression>
+        lambda_expressions: Arc<LambdaExpression>,
     ) -> PolarsResult<ListChunked> {
         let ca = self.as_list();
-        let out = ca.try_apply_amortized(|s| s.as_ref().transform(&lambda_expressions) )?;
+        let out = ca.try_apply_amortized(|s| s.as_ref().transform(&lambda_expressions))?;
         Ok(out)
     }
 
@@ -377,9 +377,7 @@ pub trait ListNameSpaceImpl: AsList {
 
     fn lst_flarion_slice(&self, (offset, length): (i64, i64)) -> ListChunked {
         let ca = self.as_list();
-        let out = ca.apply_amortized(|s| {
-            list_flarion_slice_amortized(s, offset, length)
-        });
+        let out = ca.apply_amortized(|s| list_flarion_slice_amortized(s, offset, length));
         self.same_type(out)
     }
 

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -1,9 +1,8 @@
 use std::iter::zip;
-
 #[cfg(feature = "extract_groups")]
 use arrow::array::{Array, StructArray};
 use arrow::array::{MutablePlString, Utf8ViewArray};
-use polars_core::export::regex::Regex;
+use polars_core::export::regex::{Regex, RegexBuilder};
 use polars_core::prelude::arity::{try_binary_mut_with_options, try_unary_mut_with_options};
 
 use super::*;
@@ -45,7 +44,7 @@ pub(super) fn extract_groups(
     pat: &str,
     dtype: &DataType,
 ) -> PolarsResult<Series> {
-    let reg = Regex::new(pat)?;
+    let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
     let n_fields = reg.captures_len();
     if n_fields == 1 {
         return StructChunked::from_series(
@@ -106,7 +105,7 @@ fn extract_group_array_lit(
 
     for opt_pat in pat {
         if let Some(pat) = opt_pat {
-            let reg = Regex::new(pat)?;
+            let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
             let mut locs = reg.capture_locations();
             if reg.captures_read(&mut locs, s).is_some() {
                 builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
@@ -134,7 +133,7 @@ fn extract_group_binary(
     for (opt_s, opt_pat) in zip(arr, pat) {
         match (opt_s, opt_pat) {
             (Some(s), Some(pat)) => {
-                let reg = Regex::new(pat)?;
+                let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
                 let mut locs = reg.capture_locations();
                 if reg.captures_read(&mut locs, s).is_some() {
                     builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
@@ -158,7 +157,7 @@ pub(super) fn extract_group(
     match (ca.len(), pat.len()) {
         (_, 1) => {
             if let Some(pat) = pat.get(0) {
-                let reg = Regex::new(pat)?;
+                let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
                 try_unary_mut_with_options(ca, |arr| extract_group_reg_lit(arr, &reg, group_index))
             } else {
                 Ok(StringChunked::full_null(ca.name().clone(), ca.len()))

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -1,4 +1,5 @@
 use std::iter::zip;
+
 #[cfg(feature = "extract_groups")]
 use arrow::array::{Array, StructArray};
 use arrow::array::{MutablePlString, Utf8ViewArray};

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -11,7 +11,7 @@ use polars_core::export::num::Num;
 use polars_core::export::regex::Regex;
 use polars_core::prelude::arity::*;
 use polars_utils::cache::FastFixedCache;
-use regex::escape;
+use regex::{escape, RegexBuilder};
 
 use super::*;
 #[cfg(feature = "binary_encoding")]
@@ -153,7 +153,7 @@ pub trait StringNameSpaceImpl: AsString {
                         match (opt_src, opt_pat) {
                             (Some(src), Some(pat)) => {
                                 let reg =
-                                    reg_cache.try_get_or_insert_with(pat, |p| Regex::new(p))?;
+                                    reg_cache.try_get_or_insert_with(pat, |p| RegexBuilder::new(p).size_limit(31457280).build())?;
                                 Ok(Some(reg.is_match(src)))
                             },
                             _ => Ok(None),
@@ -166,7 +166,7 @@ pub trait StringNameSpaceImpl: AsString {
                         ca,
                         pat,
                         infer_re_match(|src, pat| {
-                            let reg = reg_cache.try_get_or_insert_with(pat?, |p| Regex::new(p));
+                            let reg = reg_cache.try_get_or_insert_with(pat?, |p| RegexBuilder::new(p).size_limit(31457280).build());
                             Some(reg.ok()?.is_match(src?))
                         }),
                     ))
@@ -209,7 +209,7 @@ pub trait StringNameSpaceImpl: AsString {
             let mut rx_cache = FastFixedCache::new((ca.len() as f64).sqrt() as usize);
             let matcher = |src: Option<&str>, pat: Option<&str>| -> PolarsResult<Option<u32>> {
                 if let (Some(src), Some(pat)) = (src, pat) {
-                    let rx = rx_cache.try_get_or_insert_with(pat, |p| Regex::new(p))?;
+                    let rx = rx_cache.try_get_or_insert_with(pat, |p| RegexBuilder::new(p).size_limit(31457280).build())?;
                     return Ok(rx.find(src).map(|m| m.start() as u32));
                 }
                 Ok(None)
@@ -267,7 +267,7 @@ pub trait StringNameSpaceImpl: AsString {
     /// Check if strings contain a regex pattern.
     fn contains(&self, pat: &str, strict: bool) -> PolarsResult<BooleanChunked> {
         let ca = self.as_string();
-        let res_reg = Regex::new(pat);
+        let res_reg = RegexBuilder::new(pat).size_limit(31457280).build();
         let opt_reg = if strict { Some(res_reg?) } else { res_reg.ok() };
         let out: BooleanChunked = if let Some(reg) = opt_reg {
             unary_elementwise_values(ca, |s| reg.is_match(s))
@@ -293,7 +293,7 @@ pub trait StringNameSpaceImpl: AsString {
     /// Return the index position of a regular expression substring in the target string.
     fn find(&self, pat: &str, strict: bool) -> PolarsResult<UInt32Chunked> {
         let ca = self.as_string();
-        match Regex::new(pat) {
+        match RegexBuilder::new(pat).size_limit(31457280).build() {
             Ok(rx) => Ok(unary_elementwise(ca, |opt_s| {
                 opt_s.and_then(|s| rx.find(s)).map(|m| m.start() as u32)
             })),
@@ -306,7 +306,7 @@ pub trait StringNameSpaceImpl: AsString {
 
     /// Replace the leftmost regex-matched (sub)string with another string
     fn replace<'a>(&'a self, pat: &str, val: &str) -> PolarsResult<StringChunked> {
-        let reg = Regex::new(pat)?;
+        let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
         let f = |s: &'a str| reg.replace(s, val);
         let ca = self.as_string();
         Ok(ca.apply_values(f))
@@ -356,7 +356,7 @@ pub trait StringNameSpaceImpl: AsString {
     /// Replace all regex-matched (sub)strings with another string
     fn replace_all(&self, pat: &str, val: &str, group_index: usize) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
-        let reg = Regex::new(pat)?;
+        let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
         Ok(ca.apply_values(|s| {
             let pairs = reg
                 .captures_iter(s)
@@ -423,7 +423,7 @@ pub trait StringNameSpaceImpl: AsString {
     /// Extract each successive non-overlapping regex match in an individual string as an array.
     fn extract_all(&self, pat: &str, group_index: usize) -> PolarsResult<ListChunked> {
         let ca = self.as_string();
-        let reg = Regex::new(pat)?;
+        let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
 
         let mut builder =
             ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
@@ -530,7 +530,7 @@ pub trait StringNameSpaceImpl: AsString {
         binary_elementwise_for_each(ca, pat, |opt_s, opt_pat| match (opt_s, opt_pat) {
             (_, None) | (None, _) => builder.append_null(),
             (Some(s), Some(pat)) => {
-                let reg = reg_cache.get_or_insert_with(pat, |p| Regex::new(p).unwrap());
+                let reg = reg_cache.get_or_insert_with(pat, |p| RegexBuilder::new(p).size_limit(31457280).build().unwrap());
                 builder.append_values_iter(reg.find_iter(s).map(|m| m.as_str()));
             },
         });
@@ -548,9 +548,9 @@ pub trait StringNameSpaceImpl: AsString {
     fn count_matches(&self, pat: &str, literal: bool) -> PolarsResult<UInt32Chunked> {
         let ca = self.as_string();
         let reg = if literal {
-            Regex::new(escape(pat).as_str())?
+            RegexBuilder::new(escape(pat).as_str()).size_limit(31457280).build()?
         } else {
-            Regex::new(pat)?
+            RegexBuilder::new(pat).size_limit(31457280).build()?
         };
 
         Ok(unary_elementwise(ca, |opt_s| {
@@ -578,9 +578,9 @@ pub trait StringNameSpaceImpl: AsString {
                 (Some(s), Some(pat)) => {
                     let reg = reg_cache.get_or_insert_with(pat, |p| {
                         if literal {
-                            Regex::new(escape(p).as_str()).unwrap()
+                            RegexBuilder::new(escape(p).as_str()).size_limit(31457280).build().unwrap()
                         } else {
-                            Regex::new(p).unwrap()
+                            RegexBuilder::new(pat).size_limit(31457280).build().unwrap()
                         }
                     });
                     Ok(Some(reg.find_iter(s).count() as u32))

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -8,7 +8,6 @@ use base64::engine::general_purpose;
 use base64::Engine as _;
 #[cfg(feature = "string_to_integer")]
 use polars_core::export::num::Num;
-use polars_core::export::regex::Regex;
 use polars_core::prelude::arity::*;
 use polars_utils::cache::FastFixedCache;
 use regex::{escape, RegexBuilder};
@@ -152,8 +151,9 @@ pub trait StringNameSpaceImpl: AsString {
                     broadcast_try_binary_elementwise(ca, pat, |opt_src, opt_pat| {
                         match (opt_src, opt_pat) {
                             (Some(src), Some(pat)) => {
-                                let reg =
-                                    reg_cache.try_get_or_insert_with(pat, |p| RegexBuilder::new(p).size_limit(31457280).build())?;
+                                let reg = reg_cache.try_get_or_insert_with(pat, |p| {
+                                    RegexBuilder::new(p).size_limit(31457280).build()
+                                })?;
                                 Ok(Some(reg.is_match(src)))
                             },
                             _ => Ok(None),
@@ -166,7 +166,9 @@ pub trait StringNameSpaceImpl: AsString {
                         ca,
                         pat,
                         infer_re_match(|src, pat| {
-                            let reg = reg_cache.try_get_or_insert_with(pat?, |p| RegexBuilder::new(p).size_limit(31457280).build());
+                            let reg = reg_cache.try_get_or_insert_with(pat?, |p| {
+                                RegexBuilder::new(p).size_limit(31457280).build()
+                            });
                             Some(reg.ok()?.is_match(src?))
                         }),
                     ))
@@ -209,7 +211,9 @@ pub trait StringNameSpaceImpl: AsString {
             let mut rx_cache = FastFixedCache::new((ca.len() as f64).sqrt() as usize);
             let matcher = |src: Option<&str>, pat: Option<&str>| -> PolarsResult<Option<u32>> {
                 if let (Some(src), Some(pat)) = (src, pat) {
-                    let rx = rx_cache.try_get_or_insert_with(pat, |p| RegexBuilder::new(p).size_limit(31457280).build())?;
+                    let rx = rx_cache.try_get_or_insert_with(pat, |p| {
+                        RegexBuilder::new(p).size_limit(31457280).build()
+                    })?;
                     return Ok(rx.find(src).map(|m| m.start() as u32));
                 }
                 Ok(None)
@@ -530,7 +534,9 @@ pub trait StringNameSpaceImpl: AsString {
         binary_elementwise_for_each(ca, pat, |opt_s, opt_pat| match (opt_s, opt_pat) {
             (_, None) | (None, _) => builder.append_null(),
             (Some(s), Some(pat)) => {
-                let reg = reg_cache.get_or_insert_with(pat, |p| RegexBuilder::new(p).size_limit(31457280).build().unwrap());
+                let reg = reg_cache.get_or_insert_with(pat, |p| {
+                    RegexBuilder::new(p).size_limit(31457280).build().unwrap()
+                });
                 builder.append_values_iter(reg.find_iter(s).map(|m| m.as_str()));
             },
         });
@@ -548,7 +554,9 @@ pub trait StringNameSpaceImpl: AsString {
     fn count_matches(&self, pat: &str, literal: bool) -> PolarsResult<UInt32Chunked> {
         let ca = self.as_string();
         let reg = if literal {
-            RegexBuilder::new(escape(pat).as_str()).size_limit(31457280).build()?
+            RegexBuilder::new(escape(pat).as_str())
+                .size_limit(31457280)
+                .build()?
         } else {
             RegexBuilder::new(pat).size_limit(31457280).build()?
         };
@@ -578,7 +586,10 @@ pub trait StringNameSpaceImpl: AsString {
                 (Some(s), Some(pat)) => {
                     let reg = reg_cache.get_or_insert_with(pat, |p| {
                         if literal {
-                            RegexBuilder::new(escape(p).as_str()).size_limit(31457280).build().unwrap()
+                            RegexBuilder::new(escape(p).as_str())
+                                .size_limit(31457280)
+                                .build()
+                                .unwrap()
                         } else {
                             RegexBuilder::new(pat).size_limit(31457280).build().unwrap()
                         }

--- a/crates/polars-plan/src/dsl/function_expr/binary.rs
+++ b/crates/polars-plan/src/dsl/function_expr/binary.rs
@@ -1,5 +1,6 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
+
 use super::*;
 use crate::{map, map_as_slice};
 
@@ -87,24 +88,27 @@ impl From<BinaryFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
 }
 
 pub(super) fn concat(s: &[Series]) -> PolarsResult<Series> {
-    let ca = s.iter().map(|inner_s| inner_s.binary()).collect::<PolarsResult<Vec<_>>>()?;
+    let ca = s
+        .iter()
+        .map(|inner_s| inner_s.binary())
+        .collect::<PolarsResult<Vec<_>>>()?;
     let len = ca.iter().map(|inner_s| inner_s.len()).max().unwrap();
     Ok(BinaryChunked::from_iter((0..len).map(|idx| {
-        ca.iter().fold(None, |acc, it| {
-            match (acc, it.get(idx)) {
-                (None, Some(data)) => {
-                    let mut new_vec = Vec::with_capacity(1024);
-                    new_vec.extend_from_slice(data);
-                    Some(new_vec) },
-                (Some(mut acc), Some(data)) => {
-                    acc.extend(data);
-                    Some(acc)
-                }
-                (Some(acc), None) => Some(acc),
-                (None, None) => None
-            }
+        ca.iter().fold(None, |acc, it| match (acc, it.get(idx)) {
+            (None, Some(data)) => {
+                let mut new_vec = Vec::with_capacity(1024);
+                new_vec.extend_from_slice(data);
+                Some(new_vec)
+            },
+            (Some(mut acc), Some(data)) => {
+                acc.extend(data);
+                Some(acc)
+            },
+            (Some(acc), None) => Some(acc),
+            (None, None) => None,
         })
-    })).into_series())
+    }))
+    .into_series())
 }
 
 pub(super) fn contains(s: &[Series]) -> PolarsResult<Series> {

--- a/crates/polars-plan/src/dsl/function_expr/binary.rs
+++ b/crates/polars-plan/src/dsl/function_expr/binary.rs
@@ -1,12 +1,12 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
-
 use super::*;
 use crate::{map, map_as_slice};
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, PartialEq, Debug, Eq, Hash)]
 pub enum BinaryFunction {
+    Concat,
     Contains,
     StartsWith,
     EndsWith,
@@ -25,6 +25,7 @@ impl BinaryFunction {
     pub(super) fn get_field(&self, mapper: FieldsMapper) -> PolarsResult<Field> {
         use BinaryFunction::*;
         match self {
+            Concat => mapper.with_dtype(DataType::Binary),
             Contains { .. } => mapper.with_dtype(DataType::Boolean),
             EndsWith | StartsWith => mapper.with_dtype(DataType::Boolean),
             #[cfg(feature = "binary_encoding")]
@@ -40,6 +41,7 @@ impl Display for BinaryFunction {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         use BinaryFunction::*;
         let s = match self {
+            Concat => "concat",
             Contains { .. } => "contains",
             StartsWith => "starts_with",
             EndsWith => "ends_with",
@@ -61,6 +63,7 @@ impl From<BinaryFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
     fn from(func: BinaryFunction) -> Self {
         use BinaryFunction::*;
         match func {
+            Concat => map_as_slice!(concat),
             Contains => {
                 map_as_slice!(contains)
             },
@@ -81,6 +84,27 @@ impl From<BinaryFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             Size => map!(size_bytes),
         }
     }
+}
+
+pub(super) fn concat(s: &[Series]) -> PolarsResult<Series> {
+    let ca = s.iter().map(|inner_s| inner_s.binary()).collect::<PolarsResult<Vec<_>>>()?;
+    let len = ca.iter().map(|inner_s| inner_s.len()).max().unwrap();
+    Ok(BinaryChunked::from_iter((0..len).map(|idx| {
+        ca.iter().fold(None, |acc, it| {
+            match (acc, it.get(idx)) {
+                (None, Some(data)) => {
+                    let mut new_vec = Vec::with_capacity(1024);
+                    new_vec.extend_from_slice(data);
+                    Some(new_vec) },
+                (Some(mut acc), Some(data)) => {
+                    acc.extend(data);
+                    Some(acc)
+                }
+                (Some(acc), None) => Some(acc),
+                (None, None) => None
+            }
+        })
+    })).into_series())
 }
 
 pub(super) fn contains(s: &[Series]) -> PolarsResult<Series> {

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -60,7 +60,7 @@ pub enum ListFunction {
     FilterByFunc(Arc<LambdaExpression>),
     SortByFunc(SortOptions, Arc<LambdaExpression>),
     Transform(Arc<LambdaExpression>),
-    FlarionSlice
+    FlarionSlice,
 }
 
 impl ListFunction {
@@ -111,11 +111,9 @@ impl ListFunction {
             // Flarion functinos
             FilterByFunc(_) => mapper.with_same_dtype(),
             SortByFunc(_, _) => mapper.with_same_dtype(),
-            Transform(lambda) => {
-                match lambda.return_type() {
-                    Some(dtype) => mapper.with_dtype(dtype),
-                    None => mapper.with_same_dtype(),
-                }
+            Transform(lambda) => match lambda.return_type() {
+                Some(dtype) => mapper.with_dtype(dtype),
+                None => mapper.with_same_dtype(),
             }, // TODO: transform can produse different type
             FlarionSlice => mapper.with_same_dtype(),
         }
@@ -327,7 +325,7 @@ pub(super) fn shift(s: &[Series]) -> PolarsResult<Series> {
     list.lst_shift(periods).map(|ok| ok.into_series())
 }
 
-fn flarion_spark_offset_length(mut offset: i64, length: i64) -> PolarsResult<(i64, i64)> {
+fn flarion_spark_offset_length(offset: i64, length: i64) -> PolarsResult<(i64, i64)> {
     // SQL compat, offset 0 is an error, we index from 1
     if offset == 0 {
         polars_bail!(ComputeError: "flarion_slice() failed: Offset cannot be 0");
@@ -353,7 +351,11 @@ pub(super) fn flarion_slice(args: &mut [Series]) -> PolarsResult<Option<Series>>
                 .unwrap()
                 .extract::<i64>()
                 .unwrap_or(i64::MAX);
-            return Ok(Some(list_ca.lst_flarion_slice(flarion_spark_offset_length(offset, slice_len)?).into_series()));
+            return Ok(Some(
+                list_ca
+                    .lst_flarion_slice(flarion_spark_offset_length(offset, slice_len)?)
+                    .into_series(),
+            ));
         },
         (1, length_slice_len) => {
             check_slice_arg_shape(length_slice_len, list_ca.len(), "length")?;
@@ -390,7 +392,8 @@ pub(super) fn flarion_slice(args: &mut [Series]) -> PolarsResult<Option<Series>>
                 .map(|(opt_s, opt_offset)| match (opt_s, opt_offset) {
                     (Some(s), Some(offset)) => {
                         let (offset, length) = flarion_spark_offset_length(offset, length_slice)?;
-                        Ok(Some(list_flarion_slice_amortized(s, offset, length))) },
+                        Ok(Some(list_flarion_slice_amortized(s, offset, length)))
+                    },
                     _ => Ok(None),
                 })
                 .collect_trusted::<PolarsResult<_>>()?

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -43,10 +43,7 @@ pub enum ListFunction {
         n: i64,
         null_behavior: NullBehavior,
     },
-    FilterByFunc(Arc<LambdaExpression>),
-    Transform(Arc<LambdaExpression>),
     Sort(SortOptions),
-    SortByFunc(SortOptions, Arc<LambdaExpression>),
     Reverse,
     Unique(bool),
     NUnique,
@@ -59,6 +56,11 @@ pub enum ListFunction {
     Join(bool),
     #[cfg(feature = "dtype-array")]
     ToArray(usize),
+    // Flarion functions
+    FilterByFunc(Arc<LambdaExpression>),
+    SortByFunc(SortOptions, Arc<LambdaExpression>),
+    Transform(Arc<LambdaExpression>),
+    FlarionSlice
 }
 
 impl ListFunction {
@@ -92,15 +94,7 @@ impl ListFunction {
             ArgMax => mapper.with_dtype(IDX_DTYPE),
             #[cfg(feature = "diff")]
             Diff { .. } => mapper.with_same_dtype(),
-            FilterByFunc(_) => mapper.with_same_dtype(),
-            Transform(lambda) => {
-                match lambda.return_type() {
-                    Some(dtype) => mapper.with_dtype(dtype),
-                    None => mapper.with_same_dtype(),
-                }
-            }, // TODO: transform can produse different type
             Sort(_) => mapper.with_same_dtype(),
-            SortByFunc(_, _) => mapper.with_same_dtype(),
             Reverse => mapper.with_same_dtype(),
             Unique(_) => mapper.with_same_dtype(),
             Length => mapper.with_dtype(IDX_DTYPE),
@@ -114,6 +108,16 @@ impl ListFunction {
             #[cfg(feature = "dtype-array")]
             ToArray(width) => mapper.try_map_dtype(|dt| map_list_dtype_to_array_dtype(dt, *width)),
             NUnique => mapper.with_dtype(IDX_DTYPE),
+            // Flarion functinos
+            FilterByFunc(_) => mapper.with_same_dtype(),
+            SortByFunc(_, _) => mapper.with_same_dtype(),
+            Transform(lambda) => {
+                match lambda.return_type() {
+                    Some(dtype) => mapper.with_dtype(dtype),
+                    None => mapper.with_same_dtype(),
+                }
+            }, // TODO: transform can produse different type
+            FlarionSlice => mapper.with_same_dtype(),
         }
     }
 }
@@ -166,10 +170,7 @@ impl Display for ListFunction {
             #[cfg(feature = "diff")]
             Diff { .. } => "diff",
             Length => "length",
-            FilterByFunc(_) => "filter_by_func",
-            Transform(_) => "transform",
             Sort(_) => "sort",
-            SortByFunc(_, _) => "sort_by_func",
             Reverse => "reverse",
             Unique(is_stable) => {
                 if *is_stable {
@@ -188,6 +189,11 @@ impl Display for ListFunction {
             Join(_) => "join",
             #[cfg(feature = "dtype-array")]
             ToArray(_) => "to_array",
+            // Flarion functions
+            FilterByFunc(_) => "filter_by_func",
+            SortByFunc(_, _) => "sort_by_func",
+            Transform(_) => "transform",
+            FlarionSlice => "flarion_slice",
         };
         write!(f, "list.{name}")
     }
@@ -236,10 +242,7 @@ impl From<ListFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             ArgMax => map!(arg_max),
             #[cfg(feature = "diff")]
             Diff { n, null_behavior } => map!(diff, n, null_behavior),
-            FilterByFunc(lambda) => map!(filter_by_func, lambda.clone()),
-            Transform(lambda) => map!(transform, lambda.clone()),
             Sort(options) => map!(sort, options),
-            SortByFunc(options, lambda) => map!(sort_by_func, options, lambda.clone()),
             Reverse => map!(reverse),
             Unique(is_stable) => map!(unique, is_stable),
             #[cfg(feature = "list_sets")]
@@ -252,6 +255,11 @@ impl From<ListFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             #[cfg(feature = "dtype-array")]
             ToArray(width) => map!(to_array, width),
             NUnique => map!(n_unique),
+            // Flarion functions
+            FilterByFunc(lambda) => map!(filter_by_func, lambda.clone()),
+            SortByFunc(options, lambda) => map!(sort_by_func, options, lambda.clone()),
+            Transform(lambda) => map!(transform, lambda.clone()),
+            FlarionSlice => wrap!(flarion_slice),
         }
     }
 }
@@ -317,6 +325,98 @@ pub(super) fn shift(s: &[Series]) -> PolarsResult<Series> {
     let periods = &s[1];
 
     list.lst_shift(periods).map(|ok| ok.into_series())
+}
+
+fn flarion_spark_offset_length(mut offset: i64, length: i64) -> PolarsResult<(i64, i64)> {
+    // SQL compat, offset 0 is an error, we index from 1
+    if offset == 0 {
+        polars_bail!(ComputeError: "flarion_slice() failed: Offset cannot be 0");
+    } else if length < 0 {
+        polars_bail!(ComputeError: "flarion_slice() failed: Length cannot be negative");
+    }
+
+    // Convert to regular indexing
+    Ok((offset - 1, length))
+}
+
+pub(super) fn flarion_slice(args: &mut [Series]) -> PolarsResult<Option<Series>> {
+    let s = &args[0];
+    let list_ca = s.list()?;
+    let offset_s = &args[1];
+    let length_s = &args[2];
+
+    let mut out: ListChunked = match (offset_s.len(), length_s.len()) {
+        (1, 1) => {
+            let offset = offset_s.get(0).unwrap().try_extract::<i64>()?;
+            let slice_len = length_s
+                .get(0)
+                .unwrap()
+                .extract::<i64>()
+                .unwrap_or(i64::MAX);
+            return Ok(Some(list_ca.lst_flarion_slice(flarion_spark_offset_length(offset, slice_len)?).into_series()));
+        },
+        (1, length_slice_len) => {
+            check_slice_arg_shape(length_slice_len, list_ca.len(), "length")?;
+            let offset = offset_s.get(0).unwrap().try_extract::<i64>()?;
+            // cast to i64 as it is more likely that it is that dtype
+            // instead of usize/u64 (we never need that max length)
+            let length_ca = length_s.cast(&DataType::Int64)?;
+            let length_ca = length_ca.i64().unwrap();
+
+            list_ca
+                .amortized_iter()
+                .zip(length_ca)
+                .map(|(opt_s, opt_length)| match (opt_s, opt_length) {
+                    (Some(s), Some(length)) => Some(list_flarion_slice_amortized(s, offset, length)),
+                    _ => None,
+                })
+                .collect_trusted()
+        },
+        (offset_len, 1) => {
+            check_slice_arg_shape(offset_len, list_ca.len(), "offset")?;
+            let length_slice = length_s
+                .get(0)
+                .unwrap()
+                .try_extract::<i64>()
+                .unwrap_or(i64::MAX);
+            let offset_ca = offset_s.cast(&DataType::Int64)?;
+            let offset_ca = offset_ca.i64().unwrap();
+            list_ca
+                .amortized_iter()
+                .zip(offset_ca)
+                .map(|(opt_s, opt_offset)| match (opt_s, opt_offset) {
+                    (Some(s), Some(offset)) => Some(list_flarion_slice_amortized(s, offset, length_slice)),
+                    _ => None,
+                })
+                .collect_trusted()
+        },
+        _ => {
+            check_slice_arg_shape(offset_s.len(), list_ca.len(), "offset")?;
+            check_slice_arg_shape(length_s.len(), list_ca.len(), "length")?;
+            let offset_ca = offset_s.cast(&DataType::Int64)?;
+            let offset_ca = offset_ca.i64()?;
+            // cast to i64 as it is more likely that it is that dtype
+            // instead of usize/u64 (we never need that max length)
+            let length_ca = length_s.cast(&DataType::Int64)?;
+            let length_ca = length_ca.i64().unwrap();
+
+            list_ca
+                .amortized_iter()
+                .zip(offset_ca)
+                .zip(length_ca)
+                .map(
+                    |((opt_s, opt_offset), opt_length)| match (opt_s, opt_offset, opt_length) {
+                        (Some(s), Some(offset), Some(length)) => {
+                            Some(list_flarion_slice_amortized(s, offset, length))
+                        },
+                        _ => None,
+                    },
+                )
+                .collect_trusted()
+        },
+    };
+    out.rename(s.name().clone());
+    Ok(Some(out.into_series()))
 }
 
 //noinspection RsUnwrap

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -367,10 +367,13 @@ pub(super) fn flarion_slice(args: &mut [Series]) -> PolarsResult<Option<Series>>
                 .amortized_iter()
                 .zip(length_ca)
                 .map(|(opt_s, opt_length)| match (opt_s, opt_length) {
-                    (Some(s), Some(length)) => Some(list_flarion_slice_amortized(s, offset, length)),
-                    _ => None,
+                    (Some(s), Some(length)) => {
+                        let (offset, length) = flarion_spark_offset_length(offset, length)?;
+                        Ok(Some(list_flarion_slice_amortized(s, offset, length)))
+                    },
+                    _ => Ok(None),
                 })
-                .collect_trusted()
+                .collect_trusted::<PolarsResult<_>>()?
         },
         (offset_len, 1) => {
             check_slice_arg_shape(offset_len, list_ca.len(), "offset")?;
@@ -385,10 +388,12 @@ pub(super) fn flarion_slice(args: &mut [Series]) -> PolarsResult<Option<Series>>
                 .amortized_iter()
                 .zip(offset_ca)
                 .map(|(opt_s, opt_offset)| match (opt_s, opt_offset) {
-                    (Some(s), Some(offset)) => Some(list_flarion_slice_amortized(s, offset, length_slice)),
-                    _ => None,
+                    (Some(s), Some(offset)) => {
+                        let (offset, length) = flarion_spark_offset_length(offset, length_slice)?;
+                        Ok(Some(list_flarion_slice_amortized(s, offset, length))) },
+                    _ => Ok(None),
                 })
-                .collect_trusted()
+                .collect_trusted::<PolarsResult<_>>()?
         },
         _ => {
             check_slice_arg_shape(offset_s.len(), list_ca.len(), "offset")?;
@@ -407,12 +412,13 @@ pub(super) fn flarion_slice(args: &mut [Series]) -> PolarsResult<Option<Series>>
                 .map(
                     |((opt_s, opt_offset), opt_length)| match (opt_s, opt_offset, opt_length) {
                         (Some(s), Some(offset), Some(length)) => {
-                            Some(list_flarion_slice_amortized(s, offset, length))
+                            let (offset, length) = flarion_spark_offset_length(offset, length)?;
+                            Ok(Some(list_flarion_slice_amortized(s, offset, length)))
                         },
-                        _ => None,
+                        _ => Ok(None),
                     },
                 )
-                .collect_trusted()
+                .collect_trusted::<PolarsResult<_>>()?
         },
     };
     out.rename(s.name().clone());

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -10,6 +10,7 @@ use polars_core::utils::handle_casting_failures;
 use polars_utils::format_pl_smallstr;
 #[cfg(feature = "regex")]
 use regex::{escape, Regex};
+use regex::RegexBuilder;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
@@ -880,7 +881,7 @@ fn replace_n<'a>(
                 pat = escape(&pat)
             }
 
-            let reg = Regex::new(&pat)?;
+            let reg = RegexBuilder::new(&pat).size_limit(31457280).build()?;
             let lit = pat.chars().all(|c| !c.is_ascii_punctuation());
 
             let f = |s: &'a str, val: &'a str| {
@@ -950,7 +951,7 @@ fn replace_all<'a>(
                 pat = escape(&pat)
             }
 
-            let reg = Regex::new(&pat)?;
+            let reg = RegexBuilder::new(&pat).size_limit(31457280).build()?;
 
             let f = |s: &'a str, val: &'a str| reg.replace_all(s, val);
             Ok(iter_and_replace(ca, val, f))

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -8,9 +8,10 @@ use polars_core::chunked_array::temporal::validate_time_zone;
 use polars_core::utils::handle_casting_failures;
 #[cfg(feature = "dtype-struct")]
 use polars_utils::format_pl_smallstr;
+#[cfg(all(feature = "regex", feature = "timezones"))]
+use regex::Regex;
 #[cfg(feature = "regex")]
-use regex::{escape, Regex};
-use regex::RegexBuilder;
+use regex::{escape, RegexBuilder};
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 

--- a/crates/polars-plan/src/dsl/functions/concat.rs
+++ b/crates/polars-plan/src/dsl/functions/concat.rs
@@ -52,6 +52,23 @@ pub fn format_str<E: AsRef<[Expr]>>(format: &str, args: E) -> PolarsResult<Expr>
     Ok(concat_str(exprs, "", false))
 }
 
+/// Concat binary blobs
+pub fn concat_binary<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> PolarsResult<Expr> {
+    let s: Vec<_> = s.as_ref().iter().map(|e| e.clone().into()).collect();
+
+    polars_ensure!(!s.is_empty(), ComputeError: "`concat_binary` needs one or more expressions");
+
+    Ok(Expr::Function {
+        input: s,
+        function: FunctionExpr::BinaryExpr(BinaryFunction::Concat),
+        options: FunctionOptions {
+            collect_groups: ApplyOptions::ElementWise,
+            flags: FunctionFlags::default() | FunctionFlags::INPUT_WILDCARD_EXPANSION,
+            ..Default::default()
+        },
+    })
+}
+
 /// Concat lists entries.
 pub fn concat_list<E: AsRef<[IE]>, IE: Into<Expr> + Clone>(s: E) -> PolarsResult<Expr> {
     let s: Vec<_> = s.as_ref().iter().map(|e| e.clone().into()).collect();

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -276,6 +276,16 @@ impl ListNameSpace {
         )
     }
 
+    /// Slice every sublist.
+    pub fn flarion_slice(self, offset: Expr, length: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::ListExpr(ListFunction::FlarionSlice),
+            &[offset, length],
+            false,
+            None,
+        )
+    }
+
     /// Get the head of every sublist
     pub fn head(self, n: Expr) -> Expr {
         self.slice(lit(0), n)

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -135,9 +135,7 @@ impl ListNameSpace {
 
     pub fn transform(self, func: LambdaExpression) -> Expr {
         self.0
-            .map_private(FunctionExpr::ListExpr(ListFunction::Transform(
-                func.into(),
-            )))
+            .map_private(FunctionExpr::ListExpr(ListFunction::Transform(func.into())))
     }
 
     /// Sort every sublist.

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -163,7 +163,7 @@ impl StringNameSpace {
         // and we need to compile it here to determine the output datatype
 
         use polars_utils::format_pl_smallstr;
-        let reg = regex::Regex::new(pat)?;
+        let reg = regex::RegexBuilder::new(pat).size_limit(31457280).build()?;
         let names = reg
             .capture_names()
             .enumerate()

--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -111,7 +111,7 @@ fn expand_regex(
     exclude: &PlHashSet<PlSmallStr>,
 ) -> PolarsResult<()> {
     let re =
-        regex::Regex::new(pattern).map_err(|e| polars_err!(ComputeError: "invalid regex {}", e))?;
+        regex::RegexBuilder::new(pattern).size_limit(31457280).build().map_err(|e| polars_err!(ComputeError: "invalid regex {}", e))?;
     for name in schema.iter_names() {
         if re.is_match(name) && !exclude.contains(name.as_str()) {
             let mut new_expr = remove_exclude(expr.clone());

--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -110,8 +110,10 @@ fn expand_regex(
     pattern: &str,
     exclude: &PlHashSet<PlSmallStr>,
 ) -> PolarsResult<()> {
-    let re =
-        regex::RegexBuilder::new(pattern).size_limit(31457280).build().map_err(|e| polars_err!(ComputeError: "invalid regex {}", e))?;
+    let re = regex::RegexBuilder::new(pattern)
+        .size_limit(31457280)
+        .build()
+        .map_err(|e| polars_err!(ComputeError: "invalid regex {}", e))?;
     for name in schema.iter_names() {
         if re.is_match(name) && !exclude.contains(name.as_str()) {
             let mut new_expr = remove_exclude(expr.clone());


### PR DESCRIPTION
feat: Add concat_binary and list-string-binary concat function
fix: Triple the regex size limit using RegexBuilder to support larger regular expressions
feat: Implement flarion_slice, which is a Spark-compatible slice function