### PR TITLE
fixed indexing issue inside substring and slice

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -29,7 +29,7 @@ pub enum LambdaExpression {
     IfThenElse(Box<Self>, Box<Self>, Box<Self>),
     Length(Box<Self>),
     CaseWhen(Vec<(Self, Self)>, Box<Self>),
-    Substring(Box<Self>, Box<Self>, Option<Box<Self>>),
+    Substring(Box<Self>, Box<Self>, Box<Self>),
     Instr(Box<Self>, Box<Self>),
     Add(Box<Self>, Box<Self>),
 }
@@ -85,32 +85,36 @@ impl Hash for LambdaExpression {
     }
 }
 
-fn substring<'a>(s: AnyValue<'a>, from: AnyValue<'a>, len: Option<AnyValue<'a>>) -> AnyValue<'a> {
+fn substring<'a>(s: AnyValue<'a>, from: AnyValue<'a>, len: AnyValue<'a>) -> AnyValue<'a> {
     unsafe {
         match (s, from, len) {
-            (AnyValue::String(s), AnyValue::Int32(from), Some(AnyValue::Int32(len))) => {
-                let from = from as usize - 1;
-                let to = (from + len as usize).min(s.len());
-                let result = &s[from..to];
+            (AnyValue::String(s), AnyValue::Int32(mut from), AnyValue::Int32(len)) => {
+                if from == 0 {
+                    panic!("From can't be zero in 1 indexed string")
+                }
+                if from > 0 {
+                    from = from - 1;
+                }
+                if from < 0 {
+                    from = from + s.len() as i32;
+                }
+                
+                let to = (from + len).min(s.len() as i32);
+                let result = &s[from.max(0) as usize..to.max(0) as usize];
                 AnyValue::String(result)
             },
-            (AnyValue::String(s), AnyValue::Int32(from), None) => {
-                let from = from as usize - 1;
-                let to = s.len();
-                let result = &s[from..to];
-                AnyValue::String(result)
-            },
-            (AnyValue::Binary(bin), AnyValue::Int32(from), Some(AnyValue::Int32(len))) => {
-                let from = from as usize - 1;
-                let to = (from + len as usize).min(bin.len());
-                let result = &bin[from..to];
-                AnyValue::Binary(result)
-            },
-
-            (AnyValue::Binary(bin), AnyValue::Int32(from), None) => {
-                let from = from as usize - 1;
-                let to = bin.len();
-                let result = &bin[from..to];
+            (AnyValue::Binary(bin), AnyValue::Int32(mut from), AnyValue::Int32(len)) => {
+                if from == 0 {
+                    panic!("From can't be zero in 1 indexed binary")
+                }
+                if from > 0 {
+                    from = from - 1;
+                }
+                if from < 0 {
+                    from = from + bin.len() as i32;
+                }
+                let to = (from + len).min(bin.len() as i32);
+                let result = &bin[from.max(0) as usize..to.max(0) as usize];
                 AnyValue::Binary(result)
             },
             _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
@@ -177,9 +181,7 @@ impl LambdaExpression {
             LambdaExpression::Substring(s, from, len) => {
                 let s = s.eval_array(args);
                 let from = from.eval_array(args).cast(&DataType::Int32);
-                let len = len
-                    .as_ref()
-                    .map(|v| v.eval_array(args).cast(&DataType::Int32));
+                let len = len.eval_array(args).cast(&DataType::Int32);
                 substring(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
@@ -254,9 +256,7 @@ impl LambdaExpression {
             LambdaExpression::Substring(s, from, len) => {
                 let s = s.eval_numeric::<T>(args);
                 let from = from.eval_numeric::<T>(args).cast(&DataType::Int32);
-                let len = len
-                    .as_ref()
-                    .map(|v| v.eval_numeric::<T>(args).cast(&DataType::Int32));
+                let len = len.eval_numeric::<T>(args).cast(&DataType::Int32);
                 substring(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
@@ -331,9 +331,7 @@ impl LambdaExpression {
             LambdaExpression::Substring(s, from, len) => {
                 let s = s.eval_bool(args);
                 let from = from.eval_bool(args).cast(&DataType::Int32);
-                let len = len
-                    .as_ref()
-                    .map(|v| v.eval_bool(args).cast(&DataType::Int32));
+                let len = len.eval_bool(args).cast(&DataType::Int32);
                 substring(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
@@ -411,9 +409,7 @@ impl LambdaExpression {
             LambdaExpression::Substring(s, from, len) => {
                 let s = s.eval_slice(args);
                 let from = from.eval_slice(args).cast(&DataType::Int32);
-                let len = len
-                    .as_ref()
-                    .map(|v| v.eval_slice(args).cast(&DataType::Int32));
+                let len = len.eval_slice(args).cast(&DataType::Int32);
                 substring(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
@@ -490,9 +486,7 @@ impl LambdaExpression {
             LambdaExpression::Substring(s, from, len) => {
                 let s = s.eval_any(args);
                 let from = from.eval_any(args).cast(&DataType::Int32);
-                let len = len
-                    .as_ref()
-                    .map(|v| v.eval_any(args).cast(&DataType::Int32));
+                let len = len.eval_any(args).cast(&DataType::Int32);
                 substring(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -86,34 +86,31 @@ impl Hash for LambdaExpression {
 }
 
 fn substring<'a>(s: AnyValue<'a>, from: AnyValue<'a>, len: AnyValue<'a>) -> AnyValue<'a> {
+    fn convert_indexes(from: i32, len: i32, s_len: usize) -> (usize, usize) {
+        let mut from = from as i64;
+        let len = len as i64; // this can be int32_max
+        let s_len = s_len as i64;
+        if from == 0 {
+            panic!("From can't be zero in 1 based indexation")
+        }
+        if from > 0 {
+            from -= 1;
+        }
+        if from < 0 {
+            from = from + s_len;
+        }
+        let to = (from + len).min(s_len);
+        (from.max(0) as usize, to.max(0) as usize)
+    }
     unsafe {
         match (s, from, len) {
-            (AnyValue::String(s), AnyValue::Int32(mut from), AnyValue::Int32(len)) => {
-                if from == 0 {
-                    panic!("From can't be zero in 1 indexed string")
-                }
-                if from > 0 {
-                    from = from - 1;
-                }
-                if from < 0 {
-                    from = from + s.len() as i32;
-                }
-                
-                let to = (from + len).min(s.len() as i32);
+            (AnyValue::String(s), AnyValue::Int32(from), AnyValue::Int32(len)) => {
+                let (to, from) = convert_indexes(from, len, s.len());
                 let result = &s[from.max(0) as usize..to.max(0) as usize];
                 AnyValue::String(result)
             },
-            (AnyValue::Binary(bin), AnyValue::Int32(mut from), AnyValue::Int32(len)) => {
-                if from == 0 {
-                    panic!("From can't be zero in 1 indexed binary")
-                }
-                if from > 0 {
-                    from = from - 1;
-                }
-                if from < 0 {
-                    from = from + bin.len() as i32;
-                }
-                let to = (from + len).min(bin.len() as i32);
+            (AnyValue::Binary(bin), AnyValue::Int32(from), AnyValue::Int32(len)) => {
+                let (to, from) = convert_indexes(from, len, bin.len());
                 let result = &bin[from.max(0) as usize..to.max(0) as usize];
                 AnyValue::Binary(result)
             },

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -325,7 +325,7 @@ pub(super) fn shift(s: &[Series]) -> PolarsResult<Series> {
     list.lst_shift(periods).map(|ok| ok.into_series())
 }
 
-fn flarion_spark_offset_length(offset: i64, length: i64) -> PolarsResult<(i64, i64)> {
+fn flarion_spark_offset_length(mut offset: i64, length: i64) -> PolarsResult<(i64, i64)> {
     // SQL compat, offset 0 is an error, we index from 1
     if offset == 0 {
         polars_bail!(ComputeError: "flarion_slice() failed: Offset cannot be 0");
@@ -333,8 +333,12 @@ fn flarion_spark_offset_length(offset: i64, length: i64) -> PolarsResult<(i64, i
         polars_bail!(ComputeError: "flarion_slice() failed: Length cannot be negative");
     }
 
+    if offset > 0 {
+        offset -= 1;
+    }
+
     // Convert to regular indexing
-    Ok((offset - 1, length))
+    Ok((offset, length))
 }
 
 pub(super) fn flarion_slice(args: &mut [Series]) -> PolarsResult<Option<Series>> {


### PR DESCRIPTION
Removed unused option in lambda, because when there is no len in substring scala uses int32max
fixed indexing, because we need to -1 from offset only when index is positive