### PR TITLE
feat: Implement flarion_is_in function

### DIFF
--- a/crates/polars-ops/src/series/ops/is_in.rs
+++ b/crates/polars-ops/src/series/ops/is_in.rs
@@ -1,5 +1,5 @@
 use std::hash::Hash;
-
+use std::ops::BitOr;
 use polars_core::prelude::arity::unary_elementwise_values;
 use polars_core::prelude::*;
 use polars_core::utils::{try_get_supertype, CustomIterTools};
@@ -737,4 +737,60 @@ pub fn is_in(s: &Series, other: &Series) -> PolarsResult<BooleanChunked> {
         },
         dt => polars_bail!(opq = is_in, dt),
     }
+}
+
+pub fn flarion_is_in(s: &Series, others: &[Series]) -> PolarsResult<BooleanChunked> {
+    let others_mask = others.iter().map(|other| {
+        match s.dtype() {
+            #[cfg(feature = "dtype-categorical")]
+            DataType::Categorical(_, _) | DataType::Enum(_, _) => {
+                let ca = s.categorical().unwrap();
+                is_in_cat(ca, other)
+            },
+            #[cfg(feature = "dtype-struct")]
+            DataType::Struct(_) => {
+                let ca = s.struct_().unwrap();
+                is_in_struct(ca, other)
+            },
+            DataType::String => {
+                let ca = s.str().unwrap();
+                is_in_string(ca, other)
+            },
+            DataType::Binary => {
+                let ca = s.binary().unwrap();
+                is_in_binary(ca, other)
+            },
+            DataType::Boolean => {
+                let ca = s.bool().unwrap();
+                is_in_boolean(ca, other)
+            },
+            DataType::Null => {
+                let series_bool = s.cast(&DataType::Boolean)?;
+                let ca = series_bool.bool().unwrap();
+                Ok(ca.clone())
+            },
+            #[cfg(feature = "dtype-decimal")]
+            DataType::Decimal(_, _) => {
+                let s = s.decimal()?;
+                let other = other.decimal()?;
+                let scale = s.scale().max(other.scale());
+                let s = s.to_scale(scale)?;
+                let other = other.to_scale(scale)?.into_owned().into_series();
+
+                is_in_numeric(s.physical(), &other)
+            },
+            dt if dt.to_physical().is_numeric() => {
+                let s = s.to_physical_repr();
+                with_match_physical_numeric_polars_type!(s.dtype(), |$T| {
+                let ca: &ChunkedArray<$T> = s.as_ref().as_ref().as_ref();
+                is_in_numeric(ca, other)
+            })
+            },
+            dt => polars_bail!(opq = is_in, dt),
+        }
+    }).collect::<PolarsResult<Vec<_>>>()?;
+    Ok(others_mask.into_iter()
+        .fold(BooleanChunked::full(s.name().clone(), false, s.len()), |acc, chunk| {
+        acc.bitor(chunk)
+    }))
 }

--- a/crates/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/crates/polars-plan/src/dsl/function_expr/boolean.rs
@@ -41,6 +41,9 @@ pub enum BooleanFunction {
     AnyHorizontal,
     // Also bitwise negate
     Not,
+
+    // Flarion functions
+    FlarionIsIn
 }
 
 impl BooleanFunction {
@@ -88,6 +91,9 @@ impl Display for BooleanFunction {
             AnyHorizontal => "any_horizontal",
             AllHorizontal => "all_horizontal",
             Not => "not",
+
+            // Flarion functions
+            FlarionIsIn => "flarion_is_in"
         };
         write!(f, "{s}")
     }
@@ -120,6 +126,9 @@ impl From<BooleanFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             Not => map!(not),
             AllHorizontal => map_as_slice!(all_horizontal),
             AnyHorizontal => map_as_slice!(any_horizontal),
+
+            // Flarion functions
+            FlarionIsIn => wrap!(flarion_is_in)
         }
     }
 }
@@ -205,6 +214,13 @@ fn is_in(s: &mut [Series]) -> PolarsResult<Option<Series>> {
     let left = &s[0];
     let other = &s[1];
     polars_ops::prelude::is_in(left, other).map(|ca| Some(ca.into_series()))
+}
+
+#[cfg(feature = "is_in")]
+fn flarion_is_in(s: &mut [Series]) -> PolarsResult<Option<Series>> {
+    let left = &s[0];
+    let others = &s[1..];
+    polars_ops::prelude::flarion_is_in(left, others).map(|ca| Some(ca.into_series()))
 }
 
 fn not(s: &Series) -> PolarsResult<Series> {

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -1179,6 +1179,34 @@ impl Expr {
         }
     }
 
+    /// Check if the values of the left expression are in the lists of the right expr.
+    #[allow(clippy::wrong_self_convention)]
+    #[cfg(feature = "is_in")]
+    pub fn flarion_is_in<E: AsRef<[Expr]>>(self, others: E) -> Self {
+        let arguments = others.as_ref();
+        let have_literal = others.as_ref().iter().all(has_leaf_literal);
+
+        // lit(true).is_in() returns a scalar.
+        let returns_scalar = all_return_scalar(&self);
+
+        // If all are literals, we don't have to apply on groups, so this is faster
+        if have_literal {
+            self.map_many_private(
+                BooleanFunction::FlarionIsIn.into(),
+                arguments,
+                returns_scalar,
+                Some(Default::default()),
+            )
+        } else {
+            self.apply_many_private(
+                BooleanFunction::FlarionIsIn.into(),
+                arguments,
+                returns_scalar,
+                true,
+            )
+        }
+    }
+
     /// Sort this column by the ordering of another column evaluated from given expr.
     /// Can also be used in a group_by context to sort the groups.
     ///


### PR DESCRIPTION
This allows much much greater ease of use as it natively handles both literals, regular columns, as well as arrow arrays
This allows us to get Spark-compatible behaviour with ease