### PR TITLE
fix: not() and or() expressions on NULL values

### DIFF
--- a/crates/polars-expr/src/expressions/binary.rs
+++ b/crates/polars-expr/src/expressions/binary.rs
@@ -93,13 +93,31 @@ pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResu
             }
         },
         Operator::And => left.bitand(right),
-        Operator::Or => left.bitor(right),
+        Operator::Or => {
+            // If any of them is of dtype null, then the entire series is null,
+            // we just need to make sure we choose the actual series and not a literal or something like that,
+            // so we select the biggest len
+            if left.dtype().is_null() || right.dtype().is_null() {
+                Ok(Series::new_null(PlSmallStr::EMPTY, left.len().max(right.len())))
+            } else {
+                left.bitor(right)
+            }
+        },
         Operator::LogicalOr => left
             .cast(&DataType::Boolean)?
             .bitor(&right.cast(&DataType::Boolean)?),
-        Operator::LogicalAnd => left
-            .cast(&DataType::Boolean)?
-            .bitand(&right.cast(&DataType::Boolean)?),
+        Operator::LogicalAnd => {
+            // If any of them is of dtype null, then the entire series is null,
+            // we just need to make sure we choose the actual series and not a literal or something like that,
+            // so we select the biggest len
+            if left.dtype().is_null() || right.dtype().is_null() {
+                Ok(Series::new_null(PlSmallStr::EMPTY, left.len().max(right.len())))
+            } else {
+                left
+                    .cast(&DataType::Boolean)?
+                    .bitand(&right.cast(&DataType::Boolean)?)
+            }
+        },
         Operator::Xor => left.bitxor(right),
         Operator::Modulus => left % right,
         Operator::EqValidity => left.equal_missing(right).map(|ca| ca.into_series()),

--- a/crates/polars-expr/src/expressions/binary.rs
+++ b/crates/polars-expr/src/expressions/binary.rs
@@ -103,10 +103,7 @@ pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResu
                 left.bitor(right)
             }
         },
-        Operator::LogicalOr => left
-            .cast(&DataType::Boolean)?
-            .bitor(&right.cast(&DataType::Boolean)?),
-        Operator::LogicalAnd => {
+        Operator::LogicalOr => {
             // If any of them is of dtype null, then the entire series is null,
             // we just need to make sure we choose the actual series and not a literal or something like that,
             // so we select the biggest len
@@ -117,6 +114,11 @@ pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResu
                     .cast(&DataType::Boolean)?
                     .bitand(&right.cast(&DataType::Boolean)?)
             }
+        }
+        Operator::LogicalAnd => {
+            left
+                .cast(&DataType::Boolean)?
+                .bitand(&right.cast(&DataType::Boolean)?)
         },
         Operator::Xor => left.bitxor(right),
         Operator::Modulus => left % right,

--- a/crates/polars-expr/src/expressions/binary.rs
+++ b/crates/polars-expr/src/expressions/binary.rs
@@ -98,7 +98,10 @@ pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResu
             // we just need to make sure we choose the actual series and not a literal or something like that,
             // so we select the biggest len
             if left.dtype().is_null() || right.dtype().is_null() {
-                Ok(Series::new_null(PlSmallStr::EMPTY, left.len().max(right.len())))
+                Ok(Series::new_null(
+                    PlSmallStr::EMPTY,
+                    left.len().max(right.len()),
+                ))
             } else {
                 left.bitor(right)
             }
@@ -108,18 +111,18 @@ pub fn apply_operator(left: &Series, right: &Series, op: Operator) -> PolarsResu
             // we just need to make sure we choose the actual series and not a literal or something like that,
             // so we select the biggest len
             if left.dtype().is_null() || right.dtype().is_null() {
-                Ok(Series::new_null(PlSmallStr::EMPTY, left.len().max(right.len())))
+                Ok(Series::new_null(
+                    PlSmallStr::EMPTY,
+                    left.len().max(right.len()),
+                ))
             } else {
-                left
-                    .cast(&DataType::Boolean)?
+                left.cast(&DataType::Boolean)?
                     .bitand(&right.cast(&DataType::Boolean)?)
             }
-        }
-        Operator::LogicalAnd => {
-            left
-                .cast(&DataType::Boolean)?
-                .bitand(&right.cast(&DataType::Boolean)?)
         },
+        Operator::LogicalAnd => left
+            .cast(&DataType::Boolean)?
+            .bitand(&right.cast(&DataType::Boolean)?),
         Operator::Xor => left.bitxor(right),
         Operator::Modulus => left % right,
         Operator::EqValidity => left.equal_missing(right).map(|ca| ca.into_series()),

--- a/crates/polars-ops/src/series/ops/not.rs
+++ b/crates/polars-ops/src/series/ops/not.rs
@@ -6,6 +6,7 @@ use super::*;
 
 pub fn negate_bitwise(s: &Series) -> PolarsResult<Series> {
     match s.dtype() {
+        DataType::Null => Ok(s.clone()),
         DataType::Boolean => Ok(s.bool().unwrap().not().into_series()),
         dt if dt.is_integer() => {
             with_match_physical_integer_polars_type!(dt, |$T| {

--- a/crates/polars-plan/src/dsl/function_expr/boolean.rs
+++ b/crates/polars-plan/src/dsl/function_expr/boolean.rs
@@ -50,6 +50,7 @@ impl BooleanFunction {
                 mapper.try_map_dtype(|dtype| {
                     match dtype {
                         DataType::Boolean => Ok(DataType::Boolean),
+                        DataType::Null => Ok(DataType::Null),
                         dt if dt.is_integer() => Ok(dt.clone()),
                         dt => polars_bail!(InvalidOperation: "dtype {:?} not supported in 'not' operation", dt) 
                     }


### PR DESCRIPTION
To match spark behaviour,
Currently throws an error