### PR TITLE
fix: Add Spark-compatible split function, as our current one does not handle regex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3023,7 +3023,7 @@ dependencies = [
  "proptest",
  "rand",
  "regex",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "ryu",
  "sample-arrow2",
  "sample-std",
@@ -3585,7 +3585,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
  "unarray",
 ]
 
@@ -3935,18 +3935,18 @@ dependencies = [
  "aho-corasick",
  "memchr",
  "regex-automata",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.7"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax 0.8.4",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
@@ -3963,9 +3963,9 @@ checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "reqwest"

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -45,7 +45,9 @@ pub(super) fn extract_groups(
     pat: &str,
     dtype: &DataType,
 ) -> PolarsResult<Series> {
-    let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
+    let reg = RegexBuilder::new(pat)
+        .size_limit(30 * 1024 * 1024)
+        .build()?;
     let n_fields = reg.captures_len();
     if n_fields == 1 {
         return StructChunked::from_series(
@@ -106,7 +108,9 @@ fn extract_group_array_lit(
 
     for opt_pat in pat {
         if let Some(pat) = opt_pat {
-            let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
+            let reg = RegexBuilder::new(pat)
+                .size_limit(30 * 1024 * 1024)
+                .build()?;
             let mut locs = reg.capture_locations();
             if reg.captures_read(&mut locs, s).is_some() {
                 builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
@@ -134,7 +138,9 @@ fn extract_group_binary(
     for (opt_s, opt_pat) in zip(arr, pat) {
         match (opt_s, opt_pat) {
             (Some(s), Some(pat)) => {
-                let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
+                let reg = RegexBuilder::new(pat)
+                    .size_limit(30 * 1024 * 1024)
+                    .build()?;
                 let mut locs = reg.capture_locations();
                 if reg.captures_read(&mut locs, s).is_some() {
                     builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
@@ -158,7 +164,9 @@ pub(super) fn extract_group(
     match (ca.len(), pat.len()) {
         (_, 1) => {
             if let Some(pat) = pat.get(0) {
-                let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
+                let reg = RegexBuilder::new(pat)
+                    .size_limit(30 * 1024 * 1024)
+                    .build()?;
                 try_unary_mut_with_options(ca, |arr| extract_group_reg_lit(arr, &reg, group_index))
             } else {
                 Ok(StringChunked::full_null(ca.name().clone(), ca.len()))

--- a/crates/polars-ops/src/chunked_array/strings/extract.rs
+++ b/crates/polars-ops/src/chunked_array/strings/extract.rs
@@ -45,7 +45,7 @@ pub(super) fn extract_groups(
     pat: &str,
     dtype: &DataType,
 ) -> PolarsResult<Series> {
-    let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
+    let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
     let n_fields = reg.captures_len();
     if n_fields == 1 {
         return StructChunked::from_series(
@@ -106,7 +106,7 @@ fn extract_group_array_lit(
 
     for opt_pat in pat {
         if let Some(pat) = opt_pat {
-            let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
+            let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
             let mut locs = reg.capture_locations();
             if reg.captures_read(&mut locs, s).is_some() {
                 builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
@@ -134,7 +134,7 @@ fn extract_group_binary(
     for (opt_s, opt_pat) in zip(arr, pat) {
         match (opt_s, opt_pat) {
             (Some(s), Some(pat)) => {
-                let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
+                let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
                 let mut locs = reg.capture_locations();
                 if reg.captures_read(&mut locs, s).is_some() {
                     builder.push(locs.get(group_index).map(|(start, stop)| &s[start..stop]));
@@ -158,7 +158,7 @@ pub(super) fn extract_group(
     match (ca.len(), pat.len()) {
         (_, 1) => {
             if let Some(pat) = pat.get(0) {
-                let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
+                let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
                 try_unary_mut_with_options(ca, |arr| extract_group_reg_lit(arr, &reg, group_index))
             } else {
                 Ok(StringChunked::full_null(ca.name().clone(), ca.len()))

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -3,6 +3,17 @@ use regex::RegexBuilder;
 
 use super::*;
 
+// I'm hoping the compiler optimizes this out, but it is required for correct outputs
+#[inline]
+fn fill_empty_iter<'a, I: Iterator<Item = &'a str>>(in_iter: I) -> impl Iterator<Item = &'a str> {
+    let chars = in_iter.collect::<Vec<_>>();
+    if chars.is_empty() {
+        vec![""].into_iter()
+    } else {
+        chars.into_iter()
+    }
+}
+
 pub fn flarion_split_helper(
     ca: &StringChunked,
     pattern: &str,
@@ -13,10 +24,11 @@ pub fn flarion_split_helper(
 
     // When the regex pattern is an empty string, we split the string into characters
     if pattern.is_empty() {
-        if n >= 0 {
+        if n > 0 {
             ca.into_iter().fold(&mut builder, |builder, opt_s| {
                 match opt_s {
-                    Some(s) => builder.append_values_iter(splitn_chars(s, n as usize, false)),
+                    Some(s) => builder
+                        .append_values_iter(fill_empty_iter(splitn_chars(s, n as usize, false))),
                     None => builder.append_null(),
                 }
                 builder
@@ -24,7 +36,7 @@ pub fn flarion_split_helper(
         } else {
             ca.into_iter().fold(&mut builder, |builder, opt_s| {
                 match opt_s {
-                    Some(s) => builder.append_values_iter(split_chars(s)),
+                    Some(s) => builder.append_values_iter(fill_empty_iter(split_chars(s))),
                     None => builder.append_null(),
                 };
                 builder
@@ -34,7 +46,7 @@ pub fn flarion_split_helper(
         let re = RegexBuilder::new(pattern).size_limit(31457280).build()?;
 
         // When n is already a literal, we can check it ahead, and optimize for a negative number(no limit)
-        if n >= 0 {
+        if n > 0 {
             ca.into_iter().fold(&mut builder, |builder, opt_s| {
                 match opt_s {
                     Some(s) => builder.append_values_iter(re.splitn(s, n as usize)),
@@ -78,6 +90,7 @@ mod tests {
         let result = flarion_split_helper(&input, "", 2).unwrap().into_series();
 
         assert_eq!(result.len(), 3);
+        // When len is larger then limit, Spark returns the remainder as the last element
         assert_eq!(
             result.get(0).unwrap(),
             AnyValue::List(Series::new(PlSmallStr::EMPTY, &["h", "e"]))
@@ -141,7 +154,10 @@ mod tests {
     fn test_unicode_splitting() {
         let input = create_string_chunked("input", vec![Some("你好，世界")]);
 
-        let result = flarion_split_helper(&input, ",", -1).unwrap().into_series();
+        // This is not a regular comma!
+        let result = flarion_split_helper(&input, "，", -1)
+            .unwrap()
+            .into_series();
 
         assert_eq!(result.len(), 1);
         assert_eq!(

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -1,0 +1,478 @@
+use arrow::array::ValueSize;
+use regex::RegexBuilder;
+
+use super::*;
+
+// Helper function for a recurring pattern
+// For when no regex pattern is provided, and we only need the first n characters
+#[inline]
+fn split_charsn(builder: &mut ListStringChunkedBuilder, opt_s: Option<&str>, n: usize) {
+    match opt_s {
+        Some(s) => builder.append_values_iter(splitn_chars(s, n, false)),
+        None => builder.append_null(),
+    }
+}
+
+// Helper function for a recurring pattern
+// For when no regex pattern is provided, and we need all the characters(i.e., n is negative)
+#[inline]
+fn split_chars_no_limit(builder: &mut ListStringChunkedBuilder, opt_s: Option<&str>) {
+    match opt_s {
+        Some(s) => builder.append_values_iter(split_chars(s)),
+        None => builder.append_null(),
+    }
+}
+
+// Helper function for a recurring pattern
+// When no regex pattern is provided, we split the string into characters(and possibly take the first n characters)
+#[inline]
+fn split_chars_helper(builder: &mut ListStringChunkedBuilder, opt_s: Option<&str>, n: i32) {
+    if n >= 0 {
+        split_charsn(builder, opt_s, n as usize);
+        return;
+    }
+
+    split_chars_no_limit(builder, opt_s)
+}
+
+// Helper function for a recurring pattern
+// This can be called directly in a loop when n is a zero/positive literal, to optimize performance
+#[inline]
+fn regex_splitn(
+    builder: &mut ListStringChunkedBuilder,
+    opt_s: Option<&str>,
+    re: &regex::Regex,
+    n: usize,
+) {
+    match opt_s {
+        Some(s) => builder.append_values_iter(re.splitn(s, n)),
+        None => builder.append_null(),
+    }
+}
+
+// Helper function for a recurring pattern
+// This can be called directly in a loop when n is a negative literal, to optimize performance
+#[inline]
+fn regex_split_no_limit(
+    builder: &mut ListStringChunkedBuilder,
+    opt_s: Option<&str>,
+    re: &regex::Regex,
+) {
+    match opt_s {
+        Some(s) => builder.append_values_iter(re.split(s)),
+        None => builder.append_null(),
+    }
+}
+
+// Helper function for a recurring pattern
+// We already have the compiled regex pattern, and number of splits, and we can split the string accordingly
+#[inline]
+fn regex_split_helper(
+    builder: &mut ListStringChunkedBuilder,
+    opt_s: Option<&str>,
+    re: &regex::Regex,
+    n: i32,
+) {
+    if n >= 0 {
+        regex_splitn(builder, opt_s, re, n as usize);
+        return;
+    }
+
+    regex_split_no_limit(builder, opt_s, re)
+}
+
+// In the case where both the regex pattern, and the number of splits are literals, we can check them ahead,
+// and optimize both for an empty pattern, and for a negative number of splits(no limit)
+fn handle_all_literals(
+    ca: &StringChunked,
+    opt_by: Option<&str>,
+    opt_n: Option<i32>,
+) -> PolarsResult<ListChunked> {
+    let n = opt_n.ok_or(polars_err!(ComputeError: "n must be provided for split operation"))?;
+
+    if let Some(by) = opt_by {
+        let mut builder =
+            ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
+
+        // When the regex pattern is an empty string, we split the string into characters
+        if by.is_empty() {
+            if n >= 0 {
+                ca.into_iter().fold(&mut builder, |builder, opt_s| {
+                    split_charsn(builder, opt_s, n as usize);
+                    builder
+                });
+            } else {
+                ca.into_iter().fold(&mut builder, |builder, opt_s| {
+                    split_chars_no_limit(builder, opt_s);
+                    builder
+                });
+            };
+        } else {
+            let re = RegexBuilder::new(by).size_limit(31457280).build()?;
+
+            // When n is already a literal, we can check it ahead, and optimize for a negative number(no limit)
+            if n >= 0 {
+                ca.into_iter().fold(&mut builder, |builder, opt_s| {
+                    regex_splitn(builder, opt_s, &re, n as usize);
+                    builder
+                });
+            } else {
+                ca.into_iter().fold(&mut builder, |builder, opt_s| {
+                    regex_split_no_limit(builder, opt_s, &re);
+                    builder
+                });
+            }
+        }
+
+        return Ok(builder.finish());
+    }
+
+    Ok(ListChunked::full_null_with_dtype(
+        ca.name().clone(),
+        ca.len(),
+        &DataType::String,
+    ))
+}
+
+// If the regex pattern is a literal, we can check it ahead, and optimize for an empty literal
+fn handle_literal_by(
+    ca: &StringChunked,
+    by: Option<&str>,
+    n: &Int32Chunked,
+) -> PolarsResult<ListChunked> {
+    let mut builder =
+        ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
+    if let Some(by) = by {
+        if by.is_empty() {
+            // Not a regex pattern, but an empty string, we split the string into characters
+            for (opt_s, opt_n) in ca.into_iter().zip(n) {
+                let n = opt_n
+                    .ok_or(polars_err!(ComputeError: "n must be provided for split operation"))?;
+                split_chars_helper(&mut builder, opt_s, n);
+            }
+        } else {
+            let re = RegexBuilder::new(by).size_limit(31457280).build()?;
+
+            // Regex is provided, we compile it, and split every string accordingly
+            for (opt_s, opt_n) in ca.into_iter().zip(n) {
+                let n = opt_n
+                    .ok_or(polars_err!(ComputeError: "n must be provided for split operation"))?;
+                regex_split_helper(&mut builder, opt_s, &re, n)
+            }
+        }
+        return Ok(builder.finish());
+    }
+
+    // No regex pattern provided at all, return a full null column/list
+    Ok(ListChunked::full_null_with_dtype(
+        ca.name().clone(),
+        ca.len(),
+        &DataType::String,
+    ))
+}
+
+// When n is a literal, we can optimize ahead of time to select a better loop
+// This is the second least ideal case, where we have a literal n, but not a literal regex pattern
+// We need to compile a regex for each row
+fn handle_literal_n(
+    ca: &StringChunked,
+    by: &StringChunked,
+    n: Option<i32>,
+) -> PolarsResult<ListChunked> {
+    let n = n.ok_or(polars_err!(ComputeError: "n must be provided for split operation"))?;
+
+    let mut builder =
+        ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
+    if n >= 0 {
+        ca.into_iter()
+            .zip(by)
+            .fold(&mut builder, |builder, (opt_s, opt_by)| {
+                if let Some(by) = opt_by {
+                    if by.is_empty() {
+                        split_charsn(builder, opt_s, n as usize);
+                    } else {
+                        let re = RegexBuilder::new(by).size_limit(31457280).build().unwrap();
+                        regex_splitn(builder, opt_s, &re, n as usize);
+                    }
+                } else {
+                    builder.append_null();
+                }
+                builder
+            });
+    } else {
+        ca.into_iter()
+            .zip(by)
+            .fold(&mut builder, |builder, (opt_s, opt_by)| {
+                if let Some(by) = opt_by {
+                    if by.is_empty() {
+                        split_chars_no_limit(builder, opt_s)
+                    } else {
+                        let re = RegexBuilder::new(by).size_limit(31457280).build().unwrap();
+                        regex_split_no_limit(builder, opt_s, &re)
+                    }
+                } else {
+                    builder.append_null()
+                }
+
+                builder
+            });
+    }
+
+    Ok(builder.finish())
+}
+
+// Least ideal case, where we none of the expressions are literals, and we need to check every row, without optimization
+#[cold] // This function is not expected to be called often, if at all, so is marked cold
+fn handle_regular_case(
+    ca: &StringChunked,
+    by: &StringChunked,
+    n: &Int32Chunked,
+) -> PolarsResult<ListChunked> {
+    let mut builder =
+        ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
+    for ((opt_s, opt_by), opt_n) in ca.into_iter().zip(by).zip(n) {
+        let n = opt_n.ok_or(polars_err!(ComputeError: "n must be provided for split operation"))?;
+        if n >= 0 {
+            if let Some(by) = opt_by {
+                if by.is_empty() {
+                    split_charsn(&mut builder, opt_s, n as usize);
+                    continue;
+                }
+
+                let re = RegexBuilder::new(by).size_limit(31457280).build()?;
+                regex_splitn(&mut builder, opt_s, &re, n as usize);
+                continue;
+            }
+
+            builder.append_null();
+            continue;
+        }
+
+        if let Some(by) = opt_by {
+            if by.is_empty() {
+                split_chars_no_limit(&mut builder, opt_s);
+                continue;
+            }
+
+            let re = RegexBuilder::new(by).size_limit(31457280).build()?;
+            regex_split_no_limit(&mut builder, opt_s, &re);
+            continue;
+        }
+        builder.append_null();
+    }
+    Ok(builder.finish())
+}
+
+pub fn flarion_split_helper(
+    ca: &StringChunked,
+    by: &StringChunked,
+    n: &Int32Chunked,
+) -> PolarsResult<ListChunked> {
+    match (by.len(), n.len()) {
+        (1, 1) => handle_all_literals(ca, by.get(0), n.get(0)),
+        (1, _) => handle_literal_by(ca, by.get(0), n),
+        (_, 1) => handle_literal_n(ca, by, n.get(0)),
+        (_, _) => handle_regular_case(ca, by, n),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn create_string_chunked(name: &str, values: Vec<Option<&str>>) -> StringChunked {
+        let mut builder = StringChunkedBuilder::new(PlSmallStr::from_str(name), 10);
+        for value in values {
+            match value {
+                Some(s) => builder.append_value(s),
+                None => builder.append_null(),
+            }
+        }
+        builder.finish()
+    }
+
+    fn create_int32_chunked(name: &str, values: Vec<Option<i32>>) -> Int32Chunked {
+        Int32Chunked::from_iter_options(PlSmallStr::from_str(name), values.into_iter())
+    }
+
+    #[test]
+    fn test_split_empty_pattern() {
+        let input = create_string_chunked("input", vec![Some("hello"), Some("世界"), None]);
+        let by = create_string_chunked("by", vec![Some("")]);
+        let n = create_int32_chunked("n", vec![Some(2)]);
+
+        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+
+        assert_eq!(result.len(), 3);
+        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["h", "e"])));
+        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["世", "界"])));
+        assert!(result.get(2).unwrap().is_null());
+    }
+
+    #[test]
+    fn test_split_with_regex() {
+        let input = create_string_chunked("input", vec![
+            Some("a,b,c"),
+            Some("x;y;z"),
+            Some("1||2||3"),
+            None
+        ]);
+        let by = create_string_chunked("by", vec![Some("[,;|]+")]);
+        let n = create_int32_chunked("n", vec![Some(-1)]);
+
+        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+
+        assert_eq!(result.len(), 4);
+        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b", "c"])));
+        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["x", "y", "z"])));
+        assert_eq!(result.get(2).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["1", "2", "3"])));
+        assert!(result.get(3).unwrap().is_null());
+    }
+
+    #[test]
+    fn test_split_with_limit() {
+        let input = create_string_chunked("input", vec![Some("a,b,c,d")]);
+        let by = create_string_chunked("by", vec![Some(",")]);
+        let n = create_int32_chunked("n", vec![Some(2)]);
+
+        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b,c,d"])));
+    }
+
+    #[test]
+    fn test_split_with_variable_n() {
+        let input = create_string_chunked("input", vec![Some("a,b,c"), Some("d,e,f")]);
+        let by = create_string_chunked("by", vec![Some(",")]);
+        let n = create_int32_chunked("n", vec![Some(2), Some(3)]);
+
+        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b,c"])));
+        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"])));
+    }
+
+    #[test]
+    fn test_split_with_variable_pattern() {
+        let input = create_string_chunked("input", vec![Some("a,b,c"), Some("d|e|f")]);
+        let by = create_string_chunked("by", vec![Some(","), Some("|")]);
+        let n = create_int32_chunked("n", vec![Some(-1), Some(-1)]);
+
+        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+
+        assert_eq!(result.len(), 2);
+        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b", "c"])));
+        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"])));
+    }
+
+    #[test]
+    fn test_invalid_regex_pattern() {
+        let input = create_string_chunked("input", vec![Some("test")]);
+        let by = create_string_chunked("by", vec![Some("[")]);  // Invalid regex pattern
+        let n = create_int32_chunked("n", vec![Some(-1)]);
+
+        let result = flarion_split_helper(&input, &by, &n);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_null_n_value() {
+        let input = create_string_chunked("input", vec![Some("test")]);
+        let by = create_string_chunked("by", vec![Some(",")]);
+        let n = create_int32_chunked("n", vec![None]);
+
+        let result = flarion_split_helper(&input, &by, &n);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_null_pattern() {
+        let input = create_string_chunked("input", vec![Some("test")]);
+        let by = create_string_chunked("by", vec![None]);
+        let n = create_int32_chunked("n", vec![Some(-1)]);
+
+        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+        assert_eq!(result.len(), 1);
+        assert!(result.get(0).unwrap().is_null());
+    }
+
+    #[test]
+    fn test_unicode_splitting() {
+        let input = create_string_chunked("input", vec![Some("你好，世界")]);
+        let by = create_string_chunked("by", vec![Some("，")]);
+        let n = create_int32_chunked("n", vec![Some(-1)]);
+
+        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["你好", "世界"])));
+    }
+
+    #[test]
+    fn test_empty_input() {
+        let input = create_string_chunked("input", vec![Some("")]);
+        let by = create_string_chunked("by", vec![Some(",")]);
+        let n = create_int32_chunked("n", vec![Some(-1)]);
+
+        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &[""])));
+    }
+
+    #[test]
+    fn test_mixed_scenarios() {
+        let input = create_string_chunked(
+            "input",
+            vec![Some("a,b"), Some("c|d"), None, Some("e;f")]
+        );
+        let by = create_string_chunked(
+            "by",
+            vec![Some(","), Some("|"), Some(";"), Some(";")]
+        );
+        let n = create_int32_chunked(
+            "n",
+            vec![Some(2), Some(-1), Some(1), Some(2)]
+        );
+
+        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+
+        assert_eq!(result.len(), 4);
+        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b"])));
+        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["c", "d"])));
+        assert!(result.get(2).unwrap().is_null());
+        assert_eq!(result.get(3).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["e", "f"])));
+    }
+
+    // Helper function tests
+    #[test]
+    fn test_split_chars_helper() {
+        let mut builder = ListStringChunkedBuilder::new(PlSmallStr::EMPTY, 2, 10);
+
+        // Test with positive n
+        split_chars_helper(&mut builder, Some("hello"), 2);
+        // Test with negative n
+        split_chars_helper(&mut builder, Some("world"), -1);
+
+        let result = builder.finish().into_series();
+        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["h", "e"])));
+        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["w", "o", "r", "l", "d"])));
+    }
+
+    #[test]
+    fn test_regex_split_helper() {
+        let mut builder = ListStringChunkedBuilder::new(PlSmallStr::EMPTY, 2, 10);
+        let re = RegexBuilder::new(",").size_limit(31457280).build().unwrap();
+
+        // Test with positive n
+        regex_split_helper(&mut builder, Some("a,b,c"), &re, 2);
+        // Test with negative n
+        regex_split_helper(&mut builder, Some("d,e,f"), &re, -1);
+
+        let result = builder.finish().into_series();
+        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b,c"])));
+        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"])));
+    }
+}

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -1,4 +1,5 @@
 use arrow::array::ValueSize;
+use polars_utils::cache::FastFixedCache;
 use regex::RegexBuilder;
 
 use super::*;
@@ -108,7 +109,7 @@ fn handle_all_literals(
                 });
             };
         } else {
-            let re = RegexBuilder::new(by).size_limit(31457280).build()?;
+            let re = RegexBuilder::new(by).size_limit(31457280).build().unwrap();
 
             // When n is already a literal, we can check it ahead, and optimize for a negative number(no limit)
             if n >= 0 {
@@ -151,7 +152,7 @@ fn handle_literal_by(
                 split_chars_helper(&mut builder, opt_s, n);
             }
         } else {
-            let re = RegexBuilder::new(by).size_limit(31457280).build()?;
+            let re = RegexBuilder::new(by).size_limit(31457280).build().unwrap();
 
             // Regex is provided, we compile it, and split every string accordingly
             for (opt_s, opt_n) in ca.into_iter().zip(n) {
@@ -183,6 +184,9 @@ fn handle_literal_n(
 
     let mut builder =
         ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
+
+    // Since the regex is not a literal, we want to use a cache so we don't compile the same regex multiple times
+    let mut reg_cache = FastFixedCache::new((ca.len() as f64).sqrt() as usize);
     if n >= 0 {
         ca.into_iter()
             .zip(by)
@@ -191,8 +195,10 @@ fn handle_literal_n(
                     if by.is_empty() {
                         split_charsn(builder, opt_s, n as usize);
                     } else {
-                        let re = RegexBuilder::new(by).size_limit(31457280).build().unwrap();
-                        regex_splitn(builder, opt_s, &re, n as usize);
+                        let re = reg_cache.get_or_insert_with(by, |by| {
+                            RegexBuilder::new(by).size_limit(31457280).build().unwrap()
+                        });
+                        regex_splitn(builder, opt_s, re, n as usize);
                     }
                 } else {
                     builder.append_null();
@@ -207,8 +213,10 @@ fn handle_literal_n(
                     if by.is_empty() {
                         split_chars_no_limit(builder, opt_s)
                     } else {
-                        let re = RegexBuilder::new(by).size_limit(31457280).build().unwrap();
-                        regex_split_no_limit(builder, opt_s, &re)
+                        let re = reg_cache.get_or_insert_with(by, |by| {
+                            RegexBuilder::new(by).size_limit(31457280).build().unwrap()
+                        });
+                        regex_split_no_limit(builder, opt_s, re)
                     }
                 } else {
                     builder.append_null()
@@ -230,6 +238,9 @@ fn handle_regular_case(
 ) -> PolarsResult<ListChunked> {
     let mut builder =
         ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
+
+    // Since the regex is not a literal, we want to use a cache so we don't compile the same regex multiple times
+    let mut reg_cache = FastFixedCache::new((ca.len() as f64).sqrt() as usize);
     for ((opt_s, opt_by), opt_n) in ca.into_iter().zip(by).zip(n) {
         let n = opt_n.ok_or(polars_err!(ComputeError: "n must be provided for split operation"))?;
         if n >= 0 {
@@ -239,8 +250,10 @@ fn handle_regular_case(
                     continue;
                 }
 
-                let re = RegexBuilder::new(by).size_limit(31457280).build()?;
-                regex_splitn(&mut builder, opt_s, &re, n as usize);
+                let re = reg_cache.get_or_insert_with(by, |by| {
+                    RegexBuilder::new(by).size_limit(31457280).build().unwrap()
+                });
+                regex_splitn(&mut builder, opt_s, re, n as usize);
                 continue;
             }
 
@@ -254,8 +267,10 @@ fn handle_regular_case(
                 continue;
             }
 
-            let re = RegexBuilder::new(by).size_limit(31457280).build()?;
-            regex_split_no_limit(&mut builder, opt_s, &re);
+            let re = reg_cache.get_or_insert_with(by, |by| {
+                RegexBuilder::new(by).size_limit(31457280).build().unwrap()
+            });
+            regex_split_no_limit(&mut builder, opt_s, re);
             continue;
         }
         builder.append_null();

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -43,7 +43,9 @@ pub fn flarion_split_helper(
             });
         };
     } else {
-        let re = RegexBuilder::new(pattern).size_limit(30*1024*1024).build()?;
+        let re = RegexBuilder::new(pattern)
+            .size_limit(30 * 1024 * 1024)
+            .build()?;
 
         // When n is already a literal, we can check it ahead, and optimize for a negative number(no limit)
         if n > 0 {

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -411,13 +411,13 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "regex parse error:")]
     fn test_invalid_regex_pattern() {
         let input = create_string_chunked("input", vec![Some("test")]);
         let by = create_string_chunked("by", vec![Some("[")]); // Invalid regex pattern
         let n = create_int32_chunked("n", vec![Some(-1)]);
 
-        let result = flarion_split_helper(&input, &by, &n);
-        assert!(result.is_err());
+        let _ = flarion_split_helper(&input, &by, &n);
     }
 
     #[test]

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -1,294 +1,59 @@
 use arrow::array::ValueSize;
-use polars_utils::cache::FastFixedCache;
 use regex::RegexBuilder;
 
 use super::*;
 
-// Helper function for a recurring pattern
-// For when no regex pattern is provided, and we only need the first n characters
-#[inline]
-fn split_charsn(builder: &mut ListStringChunkedBuilder, opt_s: Option<&str>, n: usize) {
-    match opt_s {
-        Some(s) => builder.append_values_iter(splitn_chars(s, n, false)),
-        None => builder.append_null(),
-    }
-}
-
-// Helper function for a recurring pattern
-// For when no regex pattern is provided, and we need all the characters(i.e., n is negative)
-#[inline]
-fn split_chars_no_limit(builder: &mut ListStringChunkedBuilder, opt_s: Option<&str>) {
-    match opt_s {
-        Some(s) => builder.append_values_iter(split_chars(s)),
-        None => builder.append_null(),
-    }
-}
-
-// Helper function for a recurring pattern
-// When no regex pattern is provided, we split the string into characters(and possibly take the first n characters)
-#[inline]
-fn split_chars_helper(builder: &mut ListStringChunkedBuilder, opt_s: Option<&str>, n: i32) {
-    if n >= 0 {
-        split_charsn(builder, opt_s, n as usize);
-        return;
-    }
-
-    split_chars_no_limit(builder, opt_s)
-}
-
-// Helper function for a recurring pattern
-// This can be called directly in a loop when n is a zero/positive literal, to optimize performance
-#[inline]
-fn regex_splitn(
-    builder: &mut ListStringChunkedBuilder,
-    opt_s: Option<&str>,
-    re: &regex::Regex,
-    n: usize,
-) {
-    match opt_s {
-        Some(s) => builder.append_values_iter(re.splitn(s, n)),
-        None => builder.append_null(),
-    }
-}
-
-// Helper function for a recurring pattern
-// This can be called directly in a loop when n is a negative literal, to optimize performance
-#[inline]
-fn regex_split_no_limit(
-    builder: &mut ListStringChunkedBuilder,
-    opt_s: Option<&str>,
-    re: &regex::Regex,
-) {
-    match opt_s {
-        Some(s) => builder.append_values_iter(re.split(s)),
-        None => builder.append_null(),
-    }
-}
-
-// Helper function for a recurring pattern
-// We already have the compiled regex pattern, and number of splits, and we can split the string accordingly
-#[inline]
-fn regex_split_helper(
-    builder: &mut ListStringChunkedBuilder,
-    opt_s: Option<&str>,
-    re: &regex::Regex,
-    n: i32,
-) {
-    if n >= 0 {
-        regex_splitn(builder, opt_s, re, n as usize);
-        return;
-    }
-
-    regex_split_no_limit(builder, opt_s, re)
-}
-
-// In the case where both the regex pattern, and the number of splits are literals, we can check them ahead,
-// and optimize both for an empty pattern, and for a negative number of splits(no limit)
-fn handle_all_literals(
-    ca: &StringChunked,
-    opt_by: Option<&str>,
-    opt_n: Option<i32>,
-) -> PolarsResult<ListChunked> {
-    let n = opt_n.ok_or(polars_err!(ComputeError: "n must be provided for split operation"))?;
-
-    if let Some(by) = opt_by {
-        let mut builder =
-            ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
-
-        // When the regex pattern is an empty string, we split the string into characters
-        if by.is_empty() {
-            if n >= 0 {
-                ca.into_iter().fold(&mut builder, |builder, opt_s| {
-                    split_charsn(builder, opt_s, n as usize);
-                    builder
-                });
-            } else {
-                ca.into_iter().fold(&mut builder, |builder, opt_s| {
-                    split_chars_no_limit(builder, opt_s);
-                    builder
-                });
-            };
-        } else {
-            let re = RegexBuilder::new(by).size_limit(31457280).build().unwrap();
-
-            // When n is already a literal, we can check it ahead, and optimize for a negative number(no limit)
-            if n >= 0 {
-                ca.into_iter().fold(&mut builder, |builder, opt_s| {
-                    regex_splitn(builder, opt_s, &re, n as usize);
-                    builder
-                });
-            } else {
-                ca.into_iter().fold(&mut builder, |builder, opt_s| {
-                    regex_split_no_limit(builder, opt_s, &re);
-                    builder
-                });
-            }
-        }
-
-        return Ok(builder.finish());
-    }
-
-    Ok(ListChunked::full_null_with_dtype(
-        ca.name().clone(),
-        ca.len(),
-        &DataType::String,
-    ))
-}
-
-// If the regex pattern is a literal, we can check it ahead, and optimize for an empty literal
-fn handle_literal_by(
-    ca: &StringChunked,
-    by: Option<&str>,
-    n: &Int32Chunked,
-) -> PolarsResult<ListChunked> {
-    let mut builder =
-        ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
-    if let Some(by) = by {
-        if by.is_empty() {
-            // Not a regex pattern, but an empty string, we split the string into characters
-            for (opt_s, opt_n) in ca.into_iter().zip(n) {
-                let n = opt_n
-                    .ok_or(polars_err!(ComputeError: "n must be provided for split operation"))?;
-                split_chars_helper(&mut builder, opt_s, n);
-            }
-        } else {
-            let re = RegexBuilder::new(by).size_limit(31457280).build().unwrap();
-
-            // Regex is provided, we compile it, and split every string accordingly
-            for (opt_s, opt_n) in ca.into_iter().zip(n) {
-                let n = opt_n
-                    .ok_or(polars_err!(ComputeError: "n must be provided for split operation"))?;
-                regex_split_helper(&mut builder, opt_s, &re, n)
-            }
-        }
-        return Ok(builder.finish());
-    }
-
-    // No regex pattern provided at all, return a full null column/list
-    Ok(ListChunked::full_null_with_dtype(
-        ca.name().clone(),
-        ca.len(),
-        &DataType::String,
-    ))
-}
-
-// When n is a literal, we can optimize ahead of time to select a better loop
-// This is the second least ideal case, where we have a literal n, but not a literal regex pattern
-// We need to compile a regex for each row
-fn handle_literal_n(
-    ca: &StringChunked,
-    by: &StringChunked,
-    n: Option<i32>,
-) -> PolarsResult<ListChunked> {
-    let n = n.ok_or(polars_err!(ComputeError: "n must be provided for split operation"))?;
-
-    let mut builder =
-        ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
-
-    // Since the regex is not a literal, we want to use a cache so we don't compile the same regex multiple times
-    let mut reg_cache = FastFixedCache::new((ca.len() as f64).sqrt() as usize);
-    if n >= 0 {
-        ca.into_iter()
-            .zip(by)
-            .fold(&mut builder, |builder, (opt_s, opt_by)| {
-                if let Some(by) = opt_by {
-                    if by.is_empty() {
-                        split_charsn(builder, opt_s, n as usize);
-                    } else {
-                        let re = reg_cache.get_or_insert_with(by, |by| {
-                            RegexBuilder::new(by).size_limit(31457280).build().unwrap()
-                        });
-                        regex_splitn(builder, opt_s, re, n as usize);
-                    }
-                } else {
-                    builder.append_null();
-                }
-                builder
-            });
-    } else {
-        ca.into_iter()
-            .zip(by)
-            .fold(&mut builder, |builder, (opt_s, opt_by)| {
-                if let Some(by) = opt_by {
-                    if by.is_empty() {
-                        split_chars_no_limit(builder, opt_s)
-                    } else {
-                        let re = reg_cache.get_or_insert_with(by, |by| {
-                            RegexBuilder::new(by).size_limit(31457280).build().unwrap()
-                        });
-                        regex_split_no_limit(builder, opt_s, re)
-                    }
-                } else {
-                    builder.append_null()
-                }
-
-                builder
-            });
-    }
-
-    Ok(builder.finish())
-}
-
-// Least ideal case, where we none of the expressions are literals, and we need to check every row, without optimization
-#[cold] // This function is not expected to be called often, if at all, so is marked cold
-fn handle_regular_case(
-    ca: &StringChunked,
-    by: &StringChunked,
-    n: &Int32Chunked,
-) -> PolarsResult<ListChunked> {
-    let mut builder =
-        ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
-
-    // Since the regex is not a literal, we want to use a cache so we don't compile the same regex multiple times
-    let mut reg_cache = FastFixedCache::new((ca.len() as f64).sqrt() as usize);
-    for ((opt_s, opt_by), opt_n) in ca.into_iter().zip(by).zip(n) {
-        let n = opt_n.ok_or(polars_err!(ComputeError: "n must be provided for split operation"))?;
-        if n >= 0 {
-            if let Some(by) = opt_by {
-                if by.is_empty() {
-                    split_charsn(&mut builder, opt_s, n as usize);
-                    continue;
-                }
-
-                let re = reg_cache.get_or_insert_with(by, |by| {
-                    RegexBuilder::new(by).size_limit(31457280).build().unwrap()
-                });
-                regex_splitn(&mut builder, opt_s, re, n as usize);
-                continue;
-            }
-
-            builder.append_null();
-            continue;
-        }
-
-        if let Some(by) = opt_by {
-            if by.is_empty() {
-                split_chars_no_limit(&mut builder, opt_s);
-                continue;
-            }
-
-            let re = reg_cache.get_or_insert_with(by, |by| {
-                RegexBuilder::new(by).size_limit(31457280).build().unwrap()
-            });
-            regex_split_no_limit(&mut builder, opt_s, re);
-            continue;
-        }
-        builder.append_null();
-    }
-    Ok(builder.finish())
-}
-
 pub fn flarion_split_helper(
     ca: &StringChunked,
-    by: &StringChunked,
-    n: &Int32Chunked,
+    pattern: &str,
+    n: i32,
 ) -> PolarsResult<ListChunked> {
-    match (by.len(), n.len()) {
-        (1, 1) => handle_all_literals(ca, by.get(0), n.get(0)),
-        (1, _) => handle_literal_by(ca, by.get(0), n),
-        (_, 1) => handle_literal_n(ca, by, n.get(0)),
-        (_, _) => handle_regular_case(ca, by, n),
+    let mut builder =
+        ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
+
+    // When the regex pattern is an empty string, we split the string into characters
+    if pattern.is_empty() {
+        if n >= 0 {
+            ca.into_iter().fold(&mut builder, |builder, opt_s| {
+                match opt_s {
+                    Some(s) => builder.append_values_iter(splitn_chars(s, n as usize, false)),
+                    None => builder.append_null(),
+                }
+                builder
+            });
+        } else {
+            ca.into_iter().fold(&mut builder, |builder, opt_s| {
+                match opt_s {
+                    Some(s) => builder.append_values_iter(split_chars(s)),
+                    None => builder.append_null(),
+                };
+                builder
+            });
+        };
+    } else {
+        let re = RegexBuilder::new(pattern).size_limit(31457280).build()?;
+
+        // When n is already a literal, we can check it ahead, and optimize for a negative number(no limit)
+        if n >= 0 {
+            ca.into_iter().fold(&mut builder, |builder, opt_s| {
+                match opt_s {
+                    Some(s) => builder.append_values_iter(re.splitn(s, n as usize)),
+                    None => builder.append_null(),
+                };
+                builder
+            });
+        } else {
+            ca.into_iter().fold(&mut builder, |builder, opt_s| {
+                match opt_s {
+                    Some(s) => builder.append_values_iter(re.split(s)),
+                    None => builder.append_null(),
+                };
+                builder
+            });
+        }
     }
+
+    Ok(builder.finish())
 }
 
 #[cfg(test)]
@@ -306,17 +71,11 @@ mod tests {
         builder.finish()
     }
 
-    fn create_int32_chunked(name: &str, values: Vec<Option<i32>>) -> Int32Chunked {
-        Int32Chunked::from_iter_options(PlSmallStr::from_str(name), values.into_iter())
-    }
-
     #[test]
     fn test_split_empty_pattern() {
         let input = create_string_chunked("input", vec![Some("hello"), Some("世界"), None]);
-        let by = create_string_chunked("by", vec![Some("")]);
-        let n = create_int32_chunked("n", vec![Some(2)]);
 
-        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+        let result = flarion_split_helper(&input, "", 2).unwrap().into_series();
 
         assert_eq!(result.len(), 3);
         assert_eq!(
@@ -336,10 +95,10 @@ mod tests {
             "input",
             vec![Some("a,b,c"), Some("x;y;z"), Some("1||2||3"), None],
         );
-        let by = create_string_chunked("by", vec![Some("[,;|]+")]);
-        let n = create_int32_chunked("n", vec![Some(-1)]);
 
-        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+        let result = flarion_split_helper(&input, "[,;|]+", -1)
+            .unwrap()
+            .into_series();
 
         assert_eq!(result.len(), 4);
         assert_eq!(
@@ -360,10 +119,8 @@ mod tests {
     #[test]
     fn test_split_with_limit() {
         let input = create_string_chunked("input", vec![Some("a,b,c,d")]);
-        let by = create_string_chunked("by", vec![Some(",")]);
-        let n = create_int32_chunked("n", vec![Some(2)]);
 
-        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+        let result = flarion_split_helper(&input, ",", 2).unwrap().into_series();
 
         assert_eq!(result.len(), 1);
         assert_eq!(
@@ -373,81 +130,18 @@ mod tests {
     }
 
     #[test]
-    fn test_split_with_variable_n() {
-        let input = create_string_chunked("input", vec![Some("a,b,c"), Some("d,e,f")]);
-        let by = create_string_chunked("by", vec![Some(",")]);
-        let n = create_int32_chunked("n", vec![Some(2), Some(3)]);
-
-        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
-
-        assert_eq!(result.len(), 2);
-        assert_eq!(
-            result.get(0).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b,c"]))
-        );
-        assert_eq!(
-            result.get(1).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"]))
-        );
-    }
-
-    #[test]
-    fn test_split_with_variable_pattern() {
-        let input = create_string_chunked("input", vec![Some("a,b,c"), Some("d|e|f")]);
-        let by = create_string_chunked("by", vec![Some(","), Some(r"\|")]);
-        let n = create_int32_chunked("n", vec![Some(-1), Some(-1)]);
-
-        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
-
-        assert_eq!(result.len(), 2);
-        assert_eq!(
-            result.get(0).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b", "c"]))
-        );
-        assert_eq!(
-            result.get(1).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"]))
-        );
-    }
-
-    #[test]
-    #[should_panic(expected = "regex parse error:")]
     fn test_invalid_regex_pattern() {
         let input = create_string_chunked("input", vec![Some("test")]);
-        let by = create_string_chunked("by", vec![Some("[")]); // Invalid regex pattern
-        let n = create_int32_chunked("n", vec![Some(-1)]);
 
-        let _ = flarion_split_helper(&input, &by, &n);
-    }
-
-    #[test]
-    fn test_null_n_value() {
-        let input = create_string_chunked("input", vec![Some("test")]);
-        let by = create_string_chunked("by", vec![Some(",")]);
-        let n = create_int32_chunked("n", vec![None]);
-
-        let result = flarion_split_helper(&input, &by, &n);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_null_pattern() {
-        let input = create_string_chunked("input", vec![Some("test")]);
-        let by = create_string_chunked("by", vec![None]);
-        let n = create_int32_chunked("n", vec![Some(-1)]);
-
-        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
-        assert_eq!(result.len(), 1);
-        assert!(result.get(0).unwrap().is_null());
+        let res = flarion_split_helper(&input, "[", -1);
+        assert!(res.is_err());
     }
 
     #[test]
     fn test_unicode_splitting() {
         let input = create_string_chunked("input", vec![Some("你好，世界")]);
-        let by = create_string_chunked("by", vec![Some("，")]);
-        let n = create_int32_chunked("n", vec![Some(-1)]);
 
-        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+        let result = flarion_split_helper(&input, ",", -1).unwrap().into_series();
 
         assert_eq!(result.len(), 1);
         assert_eq!(
@@ -459,82 +153,13 @@ mod tests {
     #[test]
     fn test_empty_input() {
         let input = create_string_chunked("input", vec![Some("")]);
-        let by = create_string_chunked("by", vec![Some(",")]);
-        let n = create_int32_chunked("n", vec![Some(-1)]);
 
-        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
+        let result = flarion_split_helper(&input, ",", -1).unwrap().into_series();
 
         assert_eq!(result.len(), 1);
         assert_eq!(
             result.get(0).unwrap(),
             AnyValue::List(Series::new(PlSmallStr::EMPTY, &[""]))
-        );
-    }
-
-    #[test]
-    fn test_mixed_scenarios() {
-        let input =
-            create_string_chunked("input", vec![Some("a,b"), Some("c|d"), None, Some("e;f")]);
-        let by = create_string_chunked("by", vec![Some(","), Some(r"\|"), Some(";"), Some(";")]);
-        let n = create_int32_chunked("n", vec![Some(2), Some(-1), Some(1), Some(2)]);
-
-        let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
-
-        assert_eq!(result.len(), 4);
-        assert_eq!(
-            result.get(0).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b"]))
-        );
-        assert_eq!(
-            result.get(1).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["c", "d"]))
-        );
-        assert!(result.get(2).unwrap().is_null());
-        assert_eq!(
-            result.get(3).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["e", "f"]))
-        );
-    }
-
-    // Helper function tests
-    #[test]
-    fn test_split_chars_helper() {
-        let mut builder = ListStringChunkedBuilder::new(PlSmallStr::EMPTY, 2, 10);
-
-        // Test with positive n
-        split_chars_helper(&mut builder, Some("hello"), 2);
-        // Test with negative n
-        split_chars_helper(&mut builder, Some("world"), -1);
-
-        let result = builder.finish().into_series();
-        assert_eq!(
-            result.get(0).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["h", "e"]))
-        );
-        assert_eq!(
-            result.get(1).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["w", "o", "r", "l", "d"]))
-        );
-    }
-
-    #[test]
-    fn test_regex_split_helper() {
-        let mut builder = ListStringChunkedBuilder::new(PlSmallStr::EMPTY, 2, 10);
-        let re = RegexBuilder::new(",").size_limit(31457280).build().unwrap();
-
-        // Test with positive n
-        regex_split_helper(&mut builder, Some("a,b,c"), &re, 2);
-        // Test with negative n
-        regex_split_helper(&mut builder, Some("d,e,f"), &re, -1);
-
-        let result = builder.finish().into_series();
-        assert_eq!(
-            result.get(0).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b,c"]))
-        );
-        assert_eq!(
-            result.get(1).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"]))
         );
     }
 }

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -43,7 +43,7 @@ pub fn flarion_split_helper(
             });
         };
     } else {
-        let re = RegexBuilder::new(pattern).size_limit(31457280).build()?;
+        let re = RegexBuilder::new(pattern).size_limit(30*1024*1024).build()?;
 
         // When n is already a literal, we can check it ahead, and optimize for a negative number(no limit)
         if n > 0 {

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -379,7 +379,7 @@ mod tests {
     #[test]
     fn test_split_with_variable_pattern() {
         let input = create_string_chunked("input", vec![Some("a,b,c"), Some("d|e|f")]);
-        let by = create_string_chunked("by", vec![Some(","), Some("|")]);
+        let by = create_string_chunked("by", vec![Some(","), Some(r"\|")]);
         let n = create_int32_chunked("n", vec![Some(-1), Some(-1)]);
 
         let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
@@ -460,7 +460,7 @@ mod tests {
     fn test_mixed_scenarios() {
         let input =
             create_string_chunked("input", vec![Some("a,b"), Some("c|d"), None, Some("e;f")]);
-        let by = create_string_chunked("by", vec![Some(","), Some("|"), Some(";"), Some(";")]);
+        let by = create_string_chunked("by", vec![Some(","), Some(r"\|"), Some(";"), Some(";")]);
         let n = create_int32_chunked("n", vec![Some(2), Some(-1), Some(1), Some(2)]);
 
         let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -304,28 +304,41 @@ mod tests {
         let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
 
         assert_eq!(result.len(), 3);
-        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["h", "e"])));
-        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["世", "界"])));
+        assert_eq!(
+            result.get(0).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["h", "e"]))
+        );
+        assert_eq!(
+            result.get(1).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["世", "界"]))
+        );
         assert!(result.get(2).unwrap().is_null());
     }
 
     #[test]
     fn test_split_with_regex() {
-        let input = create_string_chunked("input", vec![
-            Some("a,b,c"),
-            Some("x;y;z"),
-            Some("1||2||3"),
-            None
-        ]);
+        let input = create_string_chunked(
+            "input",
+            vec![Some("a,b,c"), Some("x;y;z"), Some("1||2||3"), None],
+        );
         let by = create_string_chunked("by", vec![Some("[,;|]+")]);
         let n = create_int32_chunked("n", vec![Some(-1)]);
 
         let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
 
         assert_eq!(result.len(), 4);
-        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b", "c"])));
-        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["x", "y", "z"])));
-        assert_eq!(result.get(2).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["1", "2", "3"])));
+        assert_eq!(
+            result.get(0).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b", "c"]))
+        );
+        assert_eq!(
+            result.get(1).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["x", "y", "z"]))
+        );
+        assert_eq!(
+            result.get(2).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["1", "2", "3"]))
+        );
         assert!(result.get(3).unwrap().is_null());
     }
 
@@ -338,7 +351,10 @@ mod tests {
         let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b,c,d"])));
+        assert_eq!(
+            result.get(0).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b,c,d"]))
+        );
     }
 
     #[test]
@@ -350,8 +366,14 @@ mod tests {
         let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
 
         assert_eq!(result.len(), 2);
-        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b,c"])));
-        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"])));
+        assert_eq!(
+            result.get(0).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b,c"]))
+        );
+        assert_eq!(
+            result.get(1).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"]))
+        );
     }
 
     #[test]
@@ -363,14 +385,20 @@ mod tests {
         let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
 
         assert_eq!(result.len(), 2);
-        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b", "c"])));
-        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"])));
+        assert_eq!(
+            result.get(0).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b", "c"]))
+        );
+        assert_eq!(
+            result.get(1).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"]))
+        );
     }
 
     #[test]
     fn test_invalid_regex_pattern() {
         let input = create_string_chunked("input", vec![Some("test")]);
-        let by = create_string_chunked("by", vec![Some("[")]);  // Invalid regex pattern
+        let by = create_string_chunked("by", vec![Some("[")]); // Invalid regex pattern
         let n = create_int32_chunked("n", vec![Some(-1)]);
 
         let result = flarion_split_helper(&input, &by, &n);
@@ -407,7 +435,10 @@ mod tests {
         let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["你好", "世界"])));
+        assert_eq!(
+            result.get(0).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["你好", "世界"]))
+        );
     }
 
     #[test]
@@ -419,31 +450,35 @@ mod tests {
         let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
 
         assert_eq!(result.len(), 1);
-        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &[""])));
+        assert_eq!(
+            result.get(0).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &[""]))
+        );
     }
 
     #[test]
     fn test_mixed_scenarios() {
-        let input = create_string_chunked(
-            "input",
-            vec![Some("a,b"), Some("c|d"), None, Some("e;f")]
-        );
-        let by = create_string_chunked(
-            "by",
-            vec![Some(","), Some("|"), Some(";"), Some(";")]
-        );
-        let n = create_int32_chunked(
-            "n",
-            vec![Some(2), Some(-1), Some(1), Some(2)]
-        );
+        let input =
+            create_string_chunked("input", vec![Some("a,b"), Some("c|d"), None, Some("e;f")]);
+        let by = create_string_chunked("by", vec![Some(","), Some("|"), Some(";"), Some(";")]);
+        let n = create_int32_chunked("n", vec![Some(2), Some(-1), Some(1), Some(2)]);
 
         let result = flarion_split_helper(&input, &by, &n).unwrap().into_series();
 
         assert_eq!(result.len(), 4);
-        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b"])));
-        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["c", "d"])));
+        assert_eq!(
+            result.get(0).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b"]))
+        );
+        assert_eq!(
+            result.get(1).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["c", "d"]))
+        );
         assert!(result.get(2).unwrap().is_null());
-        assert_eq!(result.get(3).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["e", "f"])));
+        assert_eq!(
+            result.get(3).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["e", "f"]))
+        );
     }
 
     // Helper function tests
@@ -457,8 +492,14 @@ mod tests {
         split_chars_helper(&mut builder, Some("world"), -1);
 
         let result = builder.finish().into_series();
-        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["h", "e"])));
-        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["w", "o", "r", "l", "d"])));
+        assert_eq!(
+            result.get(0).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["h", "e"]))
+        );
+        assert_eq!(
+            result.get(1).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["w", "o", "r", "l", "d"]))
+        );
     }
 
     #[test]
@@ -472,7 +513,13 @@ mod tests {
         regex_split_helper(&mut builder, Some("d,e,f"), &re, -1);
 
         let result = builder.finish().into_series();
-        assert_eq!(result.get(0).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b,c"])));
-        assert_eq!(result.get(1).unwrap(), AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"])));
+        assert_eq!(
+            result.get(0).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["a", "b,c"]))
+        );
+        assert_eq!(
+            result.get(1).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["d", "e", "f"]))
+        );
     }
 }

--- a/crates/polars-ops/src/chunked_array/strings/mod.rs
+++ b/crates/polars-ops/src/chunked_array/strings/mod.rs
@@ -6,6 +6,8 @@ mod concat;
 mod extract;
 #[cfg(feature = "find_many")]
 mod find_many;
+#[cfg(feature = "strings")]
+mod flarion_split;
 #[cfg(feature = "extract_jsonpath")]
 mod json_path;
 #[cfg(feature = "strings")]

--- a/crates/polars-ops/src/chunked_array/strings/mod.rs
+++ b/crates/polars-ops/src/chunked_array/strings/mod.rs
@@ -6,7 +6,7 @@ mod concat;
 mod extract;
 #[cfg(feature = "find_many")]
 mod find_many;
-#[cfg(feature = "strings")]
+#[cfg(all(feature = "strings", feature = "dtype-struct"))]
 mod flarion_split;
 #[cfg(feature = "extract_jsonpath")]
 mod json_path;
@@ -30,7 +30,7 @@ mod unicode_internals;
 pub use concat::*;
 #[cfg(feature = "find_many")]
 pub use find_many::*;
-#[cfg(feature = "strings")]
+#[cfg(all(feature = "strings", feature = "dtype-struct"))]
 pub use flarion_split::*;
 #[cfg(feature = "extract_jsonpath")]
 pub use json_path::*;

--- a/crates/polars-ops/src/chunked_array/strings/mod.rs
+++ b/crates/polars-ops/src/chunked_array/strings/mod.rs
@@ -30,6 +30,8 @@ mod unicode_internals;
 pub use concat::*;
 #[cfg(feature = "find_many")]
 pub use find_many::*;
+#[cfg(feature = "strings")]
+pub use flarion_split::*;
 #[cfg(feature = "extract_jsonpath")]
 pub use json_path::*;
 #[cfg(feature = "strings")]
@@ -37,8 +39,6 @@ pub use namespace::*;
 use polars_core::prelude::*;
 #[cfg(feature = "strings")]
 pub use split::*;
-#[cfg(feature = "strings")]
-pub use flarion_split::*;
 #[cfg(feature = "strings")]
 pub use strip::*;
 

--- a/crates/polars-ops/src/chunked_array/strings/mod.rs
+++ b/crates/polars-ops/src/chunked_array/strings/mod.rs
@@ -38,6 +38,8 @@ use polars_core::prelude::*;
 #[cfg(feature = "strings")]
 pub use split::*;
 #[cfg(feature = "strings")]
+pub use flarion_split::*;
+#[cfg(feature = "strings")]
 pub use strip::*;
 
 pub trait AsString {

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -13,9 +13,9 @@ use polars_utils::cache::FastFixedCache;
 use regex::{escape, RegexBuilder};
 
 use super::*;
+
 #[cfg(feature = "binary_encoding")]
 use crate::chunked_array::binary::BinaryNameSpaceImpl;
-use crate::chunked_array::strings::flarion_split::flarion_split_helper;
 
 // We need this to infer the right lifetimes for the match closure.
 #[inline(always)]

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -519,10 +519,10 @@ pub trait StringNameSpaceImpl: AsString {
     }
 
     #[cfg(feature = "dtype-struct")]
-    fn flarion_split(&self, by: &StringChunked, n: &Int32Chunked) -> PolarsResult<ListChunked> {
+    fn flarion_split(&self, pattern: &str, n: i32) -> PolarsResult<ListChunked> {
         let ca = self.as_string();
 
-        flarion_split_helper(ca, by, n)
+        flarion_split_helper(ca, pattern, n)
     }
 
     /// Extract each successive non-overlapping regex match in an individual string as an array.

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -13,7 +13,6 @@ use polars_utils::cache::FastFixedCache;
 use regex::{escape, RegexBuilder};
 
 use super::*;
-
 #[cfg(feature = "binary_encoding")]
 use crate::chunked_array::binary::BinaryNameSpaceImpl;
 

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -15,6 +15,7 @@ use regex::{escape, RegexBuilder};
 use super::*;
 #[cfg(feature = "binary_encoding")]
 use crate::chunked_array::binary::BinaryNameSpaceImpl;
+use crate::chunked_array::strings::flarion_split::flarion_split_helper;
 
 // We need this to infer the right lifetimes for the match closure.
 #[inline(always)]
@@ -516,6 +517,12 @@ pub trait StringNameSpaceImpl: AsString {
         let ca = self.as_string();
 
         split_helper(ca, by, str::split_inclusive)
+    }
+
+    fn flarion_split(&self, by: &StringChunked, n: &Int32Chunked) -> PolarsResult<ListChunked> {
+        let ca = self.as_string();
+
+        flarion_split_helper(ca, by, n)
     }
 
     /// Extract each successive non-overlapping regex match in an individual string as an array.

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -518,6 +518,7 @@ pub trait StringNameSpaceImpl: AsString {
         split_helper(ca, by, str::split_inclusive)
     }
 
+    #[cfg(feature = "dtype-struct")]
     fn flarion_split(&self, by: &StringChunked, n: &Int32Chunked) -> PolarsResult<ListChunked> {
         let ca = self.as_string();
 

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -152,7 +152,7 @@ pub trait StringNameSpaceImpl: AsString {
                         match (opt_src, opt_pat) {
                             (Some(src), Some(pat)) => {
                                 let reg = reg_cache.try_get_or_insert_with(pat, |p| {
-                                    RegexBuilder::new(p).size_limit(31457280).build()
+                                    RegexBuilder::new(p).size_limit(30*1024*1024).build()
                                 })?;
                                 Ok(Some(reg.is_match(src)))
                             },
@@ -167,7 +167,7 @@ pub trait StringNameSpaceImpl: AsString {
                         pat,
                         infer_re_match(|src, pat| {
                             let reg = reg_cache.try_get_or_insert_with(pat?, |p| {
-                                RegexBuilder::new(p).size_limit(31457280).build()
+                                RegexBuilder::new(p).size_limit(30*1024*1024).build()
                             });
                             Some(reg.ok()?.is_match(src?))
                         }),
@@ -212,7 +212,7 @@ pub trait StringNameSpaceImpl: AsString {
             let matcher = |src: Option<&str>, pat: Option<&str>| -> PolarsResult<Option<u32>> {
                 if let (Some(src), Some(pat)) = (src, pat) {
                     let rx = rx_cache.try_get_or_insert_with(pat, |p| {
-                        RegexBuilder::new(p).size_limit(31457280).build()
+                        RegexBuilder::new(p).size_limit(30*1024*1024).build()
                     })?;
                     return Ok(rx.find(src).map(|m| m.start() as u32));
                 }
@@ -271,7 +271,7 @@ pub trait StringNameSpaceImpl: AsString {
     /// Check if strings contain a regex pattern.
     fn contains(&self, pat: &str, strict: bool) -> PolarsResult<BooleanChunked> {
         let ca = self.as_string();
-        let res_reg = RegexBuilder::new(pat).size_limit(31457280).build();
+        let res_reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build();
         let opt_reg = if strict { Some(res_reg?) } else { res_reg.ok() };
         let out: BooleanChunked = if let Some(reg) = opt_reg {
             unary_elementwise_values(ca, |s| reg.is_match(s))
@@ -297,7 +297,7 @@ pub trait StringNameSpaceImpl: AsString {
     /// Return the index position of a regular expression substring in the target string.
     fn find(&self, pat: &str, strict: bool) -> PolarsResult<UInt32Chunked> {
         let ca = self.as_string();
-        match RegexBuilder::new(pat).size_limit(31457280).build() {
+        match RegexBuilder::new(pat).size_limit(30*1024*1024).build() {
             Ok(rx) => Ok(unary_elementwise(ca, |opt_s| {
                 opt_s.and_then(|s| rx.find(s)).map(|m| m.start() as u32)
             })),
@@ -310,7 +310,7 @@ pub trait StringNameSpaceImpl: AsString {
 
     /// Replace the leftmost regex-matched (sub)string with another string
     fn replace<'a>(&'a self, pat: &str, val: &str) -> PolarsResult<StringChunked> {
-        let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
+        let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
         let f = |s: &'a str| reg.replace(s, val);
         let ca = self.as_string();
         Ok(ca.apply_values(f))
@@ -360,7 +360,7 @@ pub trait StringNameSpaceImpl: AsString {
     /// Replace all regex-matched (sub)strings with another string
     fn replace_all(&self, pat: &str, val: &str, group_index: usize) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
-        let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
+        let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
         Ok(ca.apply_values(|s| {
             let pairs = reg
                 .captures_iter(s)
@@ -427,7 +427,7 @@ pub trait StringNameSpaceImpl: AsString {
     /// Extract each successive non-overlapping regex match in an individual string as an array.
     fn extract_all(&self, pat: &str, group_index: usize) -> PolarsResult<ListChunked> {
         let ca = self.as_string();
-        let reg = RegexBuilder::new(pat).size_limit(31457280).build()?;
+        let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
 
         let mut builder =
             ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
@@ -542,7 +542,7 @@ pub trait StringNameSpaceImpl: AsString {
             (_, None) | (None, _) => builder.append_null(),
             (Some(s), Some(pat)) => {
                 let reg = reg_cache.get_or_insert_with(pat, |p| {
-                    RegexBuilder::new(p).size_limit(31457280).build().unwrap()
+                    RegexBuilder::new(p).size_limit(30*1024*1024).build().unwrap()
                 });
                 builder.append_values_iter(reg.find_iter(s).map(|m| m.as_str()));
             },
@@ -562,10 +562,10 @@ pub trait StringNameSpaceImpl: AsString {
         let ca = self.as_string();
         let reg = if literal {
             RegexBuilder::new(escape(pat).as_str())
-                .size_limit(31457280)
+                .size_limit(30*1024*1024)
                 .build()?
         } else {
-            RegexBuilder::new(pat).size_limit(31457280).build()?
+            RegexBuilder::new(pat).size_limit(30*1024*1024).build()?
         };
 
         Ok(unary_elementwise(ca, |opt_s| {
@@ -594,11 +594,11 @@ pub trait StringNameSpaceImpl: AsString {
                     let reg = reg_cache.get_or_insert_with(pat, |p| {
                         if literal {
                             RegexBuilder::new(escape(p).as_str())
-                                .size_limit(31457280)
+                                .size_limit(30*1024*1024)
                                 .build()
                                 .unwrap()
                         } else {
-                            RegexBuilder::new(pat).size_limit(31457280).build().unwrap()
+                            RegexBuilder::new(pat).size_limit(30*1024*1024).build().unwrap()
                         }
                     });
                     Ok(Some(reg.find_iter(s).count() as u32))

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -152,7 +152,7 @@ pub trait StringNameSpaceImpl: AsString {
                         match (opt_src, opt_pat) {
                             (Some(src), Some(pat)) => {
                                 let reg = reg_cache.try_get_or_insert_with(pat, |p| {
-                                    RegexBuilder::new(p).size_limit(30*1024*1024).build()
+                                    RegexBuilder::new(p).size_limit(30 * 1024 * 1024).build()
                                 })?;
                                 Ok(Some(reg.is_match(src)))
                             },
@@ -167,7 +167,7 @@ pub trait StringNameSpaceImpl: AsString {
                         pat,
                         infer_re_match(|src, pat| {
                             let reg = reg_cache.try_get_or_insert_with(pat?, |p| {
-                                RegexBuilder::new(p).size_limit(30*1024*1024).build()
+                                RegexBuilder::new(p).size_limit(30 * 1024 * 1024).build()
                             });
                             Some(reg.ok()?.is_match(src?))
                         }),
@@ -212,7 +212,7 @@ pub trait StringNameSpaceImpl: AsString {
             let matcher = |src: Option<&str>, pat: Option<&str>| -> PolarsResult<Option<u32>> {
                 if let (Some(src), Some(pat)) = (src, pat) {
                     let rx = rx_cache.try_get_or_insert_with(pat, |p| {
-                        RegexBuilder::new(p).size_limit(30*1024*1024).build()
+                        RegexBuilder::new(p).size_limit(30 * 1024 * 1024).build()
                     })?;
                     return Ok(rx.find(src).map(|m| m.start() as u32));
                 }
@@ -271,7 +271,7 @@ pub trait StringNameSpaceImpl: AsString {
     /// Check if strings contain a regex pattern.
     fn contains(&self, pat: &str, strict: bool) -> PolarsResult<BooleanChunked> {
         let ca = self.as_string();
-        let res_reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build();
+        let res_reg = RegexBuilder::new(pat).size_limit(30 * 1024 * 1024).build();
         let opt_reg = if strict { Some(res_reg?) } else { res_reg.ok() };
         let out: BooleanChunked = if let Some(reg) = opt_reg {
             unary_elementwise_values(ca, |s| reg.is_match(s))
@@ -297,7 +297,7 @@ pub trait StringNameSpaceImpl: AsString {
     /// Return the index position of a regular expression substring in the target string.
     fn find(&self, pat: &str, strict: bool) -> PolarsResult<UInt32Chunked> {
         let ca = self.as_string();
-        match RegexBuilder::new(pat).size_limit(30*1024*1024).build() {
+        match RegexBuilder::new(pat).size_limit(30 * 1024 * 1024).build() {
             Ok(rx) => Ok(unary_elementwise(ca, |opt_s| {
                 opt_s.and_then(|s| rx.find(s)).map(|m| m.start() as u32)
             })),
@@ -310,7 +310,9 @@ pub trait StringNameSpaceImpl: AsString {
 
     /// Replace the leftmost regex-matched (sub)string with another string
     fn replace<'a>(&'a self, pat: &str, val: &str) -> PolarsResult<StringChunked> {
-        let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
+        let reg = RegexBuilder::new(pat)
+            .size_limit(30 * 1024 * 1024)
+            .build()?;
         let f = |s: &'a str| reg.replace(s, val);
         let ca = self.as_string();
         Ok(ca.apply_values(f))
@@ -360,7 +362,9 @@ pub trait StringNameSpaceImpl: AsString {
     /// Replace all regex-matched (sub)strings with another string
     fn replace_all(&self, pat: &str, val: &str, group_index: usize) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
-        let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
+        let reg = RegexBuilder::new(pat)
+            .size_limit(30 * 1024 * 1024)
+            .build()?;
         Ok(ca.apply_values(|s| {
             let pairs = reg
                 .captures_iter(s)
@@ -427,7 +431,9 @@ pub trait StringNameSpaceImpl: AsString {
     /// Extract each successive non-overlapping regex match in an individual string as an array.
     fn extract_all(&self, pat: &str, group_index: usize) -> PolarsResult<ListChunked> {
         let ca = self.as_string();
-        let reg = RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
+        let reg = RegexBuilder::new(pat)
+            .size_limit(30 * 1024 * 1024)
+            .build()?;
 
         let mut builder =
             ListStringChunkedBuilder::new(ca.name().clone(), ca.len(), ca.get_values_size());
@@ -542,7 +548,10 @@ pub trait StringNameSpaceImpl: AsString {
             (_, None) | (None, _) => builder.append_null(),
             (Some(s), Some(pat)) => {
                 let reg = reg_cache.get_or_insert_with(pat, |p| {
-                    RegexBuilder::new(p).size_limit(30*1024*1024).build().unwrap()
+                    RegexBuilder::new(p)
+                        .size_limit(30 * 1024 * 1024)
+                        .build()
+                        .unwrap()
                 });
                 builder.append_values_iter(reg.find_iter(s).map(|m| m.as_str()));
             },
@@ -562,10 +571,12 @@ pub trait StringNameSpaceImpl: AsString {
         let ca = self.as_string();
         let reg = if literal {
             RegexBuilder::new(escape(pat).as_str())
-                .size_limit(30*1024*1024)
+                .size_limit(30 * 1024 * 1024)
                 .build()?
         } else {
-            RegexBuilder::new(pat).size_limit(30*1024*1024).build()?
+            RegexBuilder::new(pat)
+                .size_limit(30 * 1024 * 1024)
+                .build()?
         };
 
         Ok(unary_elementwise(ca, |opt_s| {
@@ -594,11 +605,14 @@ pub trait StringNameSpaceImpl: AsString {
                     let reg = reg_cache.get_or_insert_with(pat, |p| {
                         if literal {
                             RegexBuilder::new(escape(p).as_str())
-                                .size_limit(30*1024*1024)
+                                .size_limit(30 * 1024 * 1024)
                                 .build()
                                 .unwrap()
                         } else {
-                            RegexBuilder::new(pat).size_limit(30*1024*1024).build().unwrap()
+                            RegexBuilder::new(pat)
+                                .size_limit(30 * 1024 * 1024)
+                                .build()
+                                .unwrap()
                         }
                     });
                     Ok(Some(reg.find_iter(s).count() as u32))

--- a/crates/polars-ops/src/chunked_array/strings/split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/split.rs
@@ -36,7 +36,7 @@ impl<'a> Iterator for SplitNChars<'a> {
 /// Returns at most n strings, where the last string is the entire remainder
 /// of the string if keep_remainder is True, and just the nth character otherwise.
 #[cfg(feature = "dtype-struct")]
-fn splitn_chars(s: &str, n: usize, keep_remainder: bool) -> SplitNChars<'_> {
+pub(super) fn splitn_chars(s: &str, n: usize, keep_remainder: bool) -> SplitNChars<'_> {
     SplitNChars {
         s,
         n,
@@ -45,7 +45,7 @@ fn splitn_chars(s: &str, n: usize, keep_remainder: bool) -> SplitNChars<'_> {
 }
 
 /// Splits a string into substrings consisting of single characters.
-fn split_chars(s: &str) -> SplitNChars<'_> {
+pub(super) fn split_chars(s: &str) -> SplitNChars<'_> {
     SplitNChars {
         s,
         n: usize::MAX,

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -133,6 +133,9 @@ pub enum StringFunction {
         ascii_case_insensitive: bool,
         overlapping: bool,
     },
+
+    // Flarion functions
+    FlarionSplit,
 }
 
 impl StringFunction {
@@ -200,6 +203,8 @@ impl StringFunction {
             ReplaceMany { .. } => mapper.with_same_dtype(),
             #[cfg(feature = "find_many")]
             ExtractMany { .. } => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
+
+            FlarionSplit => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
         }
     }
 }
@@ -288,6 +293,9 @@ impl Display for StringFunction {
             ReplaceMany { .. } => "replace_many",
             #[cfg(feature = "find_many")]
             ExtractMany { .. } => "extract_many",
+
+            // Flarion functions
+            FlarionSplit => "flarion_split",
         };
         write!(f, "str.{s}")
     }
@@ -406,6 +414,11 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
                 overlapping,
             } => {
                 map_as_slice!(extract_many, ascii_case_insensitive, overlapping)
+            },
+
+            // Flarion functions
+            FlarionSplit => {
+                map_as_slice!(strings::flarion_split)
             },
         }
     }
@@ -663,6 +676,14 @@ pub(super) fn split(s: &[Series], inclusive: bool) -> PolarsResult<Series> {
     } else {
         Ok(ca.split(by).into_series())
     }
+}
+
+pub(super) fn flarion_split(s: &[Series]) -> PolarsResult<Series> {
+    let ca = s[0].str()?;
+    let by = s[1].str()?;
+    let n = s[2].i32()?;
+
+    ca.flarion_split(by, n).map(ListChunked::into_series)
 }
 
 #[cfg(feature = "dtype-date")]

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -136,7 +136,10 @@ pub enum StringFunction {
 
     // Flarion functions
     #[cfg(all(feature = "regex", feature = "dtype-struct"))]
-    FlarionSplit,
+    FlarionSplit {
+        pattern: PlSmallStr,
+        n: i32,
+    },
 }
 
 impl StringFunction {
@@ -206,7 +209,7 @@ impl StringFunction {
             ExtractMany { .. } => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
 
             #[cfg(all(feature = "regex", feature = "dtype-struct"))]
-            FlarionSplit => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
+            FlarionSplit { .. } => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
         }
     }
 }
@@ -298,7 +301,7 @@ impl Display for StringFunction {
 
             // Flarion functions
             #[cfg(all(feature = "regex", feature = "dtype-struct"))]
-            FlarionSplit => "flarion_split",
+            FlarionSplit { .. } => "flarion_split",
         };
         write!(f, "str.{s}")
     }
@@ -421,8 +424,8 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
 
             // Flarion functions
             #[cfg(all(feature = "regex", feature = "dtype-struct"))]
-            FlarionSplit => {
-                map_as_slice!(strings::flarion_split)
+            FlarionSplit { pattern, n } => {
+                map_as_slice!(strings::flarion_split, pattern.as_str(), n)
             },
         }
     }
@@ -683,12 +686,10 @@ pub(super) fn split(s: &[Series], inclusive: bool) -> PolarsResult<Series> {
 }
 
 #[cfg(all(feature = "regex", feature = "dtype-struct"))]
-pub(super) fn flarion_split(s: &[Series]) -> PolarsResult<Series> {
+pub(super) fn flarion_split(s: &[Series], pattern: &str, n: i32) -> PolarsResult<Series> {
     let ca = s[0].str()?;
-    let by = s[1].str()?;
-    let n = s[2].i32()?;
 
-    ca.flarion_split(by, n).map(ListChunked::into_series)
+    ca.flarion_split(pattern, n).map(ListChunked::into_series)
 }
 
 #[cfg(feature = "dtype-date")]

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -909,7 +909,9 @@ fn replace_n<'a>(
                 pat = escape(&pat)
             }
 
-            let reg = RegexBuilder::new(&pat).size_limit(30*1024*1024).build()?;
+            let reg = RegexBuilder::new(&pat)
+                .size_limit(30 * 1024 * 1024)
+                .build()?;
             let lit = pat.chars().all(|c| !c.is_ascii_punctuation());
 
             let f = |s: &'a str, val: &'a str| {
@@ -979,7 +981,9 @@ fn replace_all<'a>(
                 pat = escape(&pat)
             }
 
-            let reg = RegexBuilder::new(&pat).size_limit(30*1024*1024).build()?;
+            let reg = RegexBuilder::new(&pat)
+                .size_limit(30 * 1024 * 1024)
+                .build()?;
 
             let f = |s: &'a str, val: &'a str| reg.replace_all(s, val);
             Ok(iter_and_replace(ca, val, f))

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -135,6 +135,7 @@ pub enum StringFunction {
     },
 
     // Flarion functions
+    #[cfg(all(feature = "regex", feature = "dtype-struct"))]
     FlarionSplit,
 }
 
@@ -204,6 +205,7 @@ impl StringFunction {
             #[cfg(feature = "find_many")]
             ExtractMany { .. } => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
 
+            #[cfg(all(feature = "regex", feature = "dtype-struct"))]
             FlarionSplit => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
         }
     }
@@ -295,6 +297,7 @@ impl Display for StringFunction {
             ExtractMany { .. } => "extract_many",
 
             // Flarion functions
+            #[cfg(all(feature = "regex", feature = "dtype-struct"))]
             FlarionSplit => "flarion_split",
         };
         write!(f, "str.{s}")
@@ -417,6 +420,7 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             },
 
             // Flarion functions
+            #[cfg(all(feature = "regex", feature = "dtype-struct"))]
             FlarionSplit => {
                 map_as_slice!(strings::flarion_split)
             },
@@ -678,6 +682,7 @@ pub(super) fn split(s: &[Series], inclusive: bool) -> PolarsResult<Series> {
     }
 }
 
+#[cfg(all(feature = "regex", feature = "dtype-struct"))]
 pub(super) fn flarion_split(s: &[Series]) -> PolarsResult<Series> {
     let ca = s[0].str()?;
     let by = s[1].str()?;

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -909,7 +909,7 @@ fn replace_n<'a>(
                 pat = escape(&pat)
             }
 
-            let reg = RegexBuilder::new(&pat).size_limit(31457280).build()?;
+            let reg = RegexBuilder::new(&pat).size_limit(30*1024*1024).build()?;
             let lit = pat.chars().all(|c| !c.is_ascii_punctuation());
 
             let f = |s: &'a str, val: &'a str| {
@@ -979,7 +979,7 @@ fn replace_all<'a>(
                 pat = escape(&pat)
             }
 
-            let reg = RegexBuilder::new(&pat).size_limit(31457280).build()?;
+            let reg = RegexBuilder::new(&pat).size_limit(30*1024*1024).build()?;
 
             let f = |s: &'a str, val: &'a str| reg.replace_all(s, val);
             Ok(iter_and_replace(ca, val, f))

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -163,7 +163,7 @@ impl StringNameSpace {
         // and we need to compile it here to determine the output datatype
 
         use polars_utils::format_pl_smallstr;
-        let reg = regex::RegexBuilder::new(pat).size_limit(31457280).build()?;
+        let reg = regex::RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
         let names = reg
             .capture_names()
             .enumerate()

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -606,6 +606,7 @@ impl StringNameSpace {
     }
 }
 
+// Flarion functions
 impl StringNameSpace {
     /// Extract each successive non-overlapping match in an individual string as an array
     pub fn extract_all_with_group(self, pat: Expr, group_idx: usize) -> Expr {
@@ -636,5 +637,11 @@ impl StringNameSpace {
             false,
             Some(Default::default()),
         )
+    }
+
+    /// Split the string by a substring regex. The resulting dtype is `List<String>`.
+    pub fn flarion_split(self, by: Expr, n: Expr) -> Expr {
+        self.0
+            .map_many_private(StringFunction::FlarionSplit.into(), &[by, n], false, None)
     }
 }

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -641,8 +641,13 @@ impl StringNameSpace {
 
     /// Split the string by a substring regex. The resulting dtype is `List<String>`.
     #[cfg(all(feature = "regex", feature = "dtype-struct"))]
-    pub fn flarion_split(self, by: Expr, n: Expr) -> Expr {
-        self.0
-            .map_many_private(StringFunction::FlarionSplit.into(), &[by, n], false, None)
+    pub fn flarion_split(self, pattern: &str, n: i32) -> Expr {
+        self.0.map_private(
+            StringFunction::FlarionSplit {
+                pattern: PlSmallStr::from_str(pattern),
+                n,
+            }
+            .into(),
+        )
     }
 }

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -163,7 +163,9 @@ impl StringNameSpace {
         // and we need to compile it here to determine the output datatype
 
         use polars_utils::format_pl_smallstr;
-        let reg = regex::RegexBuilder::new(pat).size_limit(30*1024*1024).build()?;
+        let reg = regex::RegexBuilder::new(pat)
+            .size_limit(30 * 1024 * 1024)
+            .build()?;
         let names = reg
             .capture_names()
             .enumerate()

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -640,6 +640,7 @@ impl StringNameSpace {
     }
 
     /// Split the string by a substring regex. The resulting dtype is `List<String>`.
+    #[cfg(all(feature = "regex", feature = "dtype-struct"))]
     pub fn flarion_split(self, by: Expr, n: Expr) -> Expr {
         self.0
             .map_many_private(StringFunction::FlarionSplit.into(), &[by, n], false, None)

--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -111,7 +111,7 @@ fn expand_regex(
     exclude: &PlHashSet<PlSmallStr>,
 ) -> PolarsResult<()> {
     let re = regex::RegexBuilder::new(pattern)
-        .size_limit(31457280)
+        .size_limit(30*1024*1024)
         .build()
         .map_err(|e| polars_err!(ComputeError: "invalid regex {}", e))?;
     for name in schema.iter_names() {

--- a/crates/polars-plan/src/plans/conversion/expr_expansion.rs
+++ b/crates/polars-plan/src/plans/conversion/expr_expansion.rs
@@ -111,7 +111,7 @@ fn expand_regex(
     exclude: &PlHashSet<PlSmallStr>,
 ) -> PolarsResult<()> {
     let re = regex::RegexBuilder::new(pattern)
-        .size_limit(30*1024*1024)
+        .size_limit(30 * 1024 * 1024)
         .build()
         .map_err(|e| polars_err!(ComputeError: "invalid regex {}", e))?;
     for name in schema.iter_names() {

--- a/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
+++ b/crates/polars-python/src/lazyframe/visitor/expr_nodes.rs
@@ -924,6 +924,7 @@ pub(crate) fn into_py(py: Python<'_>, expr: &AExpr) -> PyResult<PyObject> {
                     StringFunction::ExtractMany { .. } => {
                         return Err(PyNotImplementedError::new_err("extract_many"))
                     },
+                    _ => unreachable!(),
                 },
                 FunctionExpr::StructExpr(_) => {
                     return Err(PyNotImplementedError::new_err("struct expr"))


### PR DESCRIPTION
Adds a regex-compatible split function that mirrors Apache Spark's behavior when splitting strings with regex patterns. The current implementation only handles literal string delimiters.