### PR TITLE
fix: Better support for lambda expressions related to filter

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -115,7 +115,7 @@ impl ChunkedArray<ListType> {
                     // Convert the series to a boolean indicating if the condition is true for any/all elements
                     match series.bool() {
                         Ok(bool_arr) => bool_arr.any(),
-                        _ => panic!("Lambda expression did not return boolean values")
+                        _ => panic!("Lambda expression did not return boolean values"),
                     }
                 },
                 _ => panic!("Lambda must return boolean values or list of boolean values"),

--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -91,7 +91,6 @@ impl ChunkedArray<ListType> {
         lambda: &LambdaExpression,
     ) -> PolarsResult<ChunkedArray<ListType>> {
         if let Some((threshold, is_greater)) = is_length_comparison(lambda) {
-            // Use optimized length-based filtering
             let mask = self.iter().map(|opt_val| match opt_val {
                 Some(arr) => {
                     let len = arr.len();
@@ -103,19 +102,26 @@ impl ChunkedArray<ListType> {
                 },
                 None => false,
             });
-
             let bool_mask = BooleanChunked::from_iter_values(self.name().clone(), mask);
             return self.filter(&bool_mask);
         }
 
+        // Evaluate each array element using eval_array
         let mask = self.iter().map(|opt_val| match opt_val {
             Some(arr) => match lambda.eval_array(&[arr.as_ref()]) {
                 AnyValue::Boolean(b) => b,
-                _ => panic!("Lambda must return boolean values"),
+                // For list operations, we should get a List back containing booleans
+                AnyValue::List(series) => {
+                    // Convert the series to a boolean indicating if the condition is true for any/all elements
+                    match series.bool() {
+                        Ok(bool_arr) => bool_arr.any(),
+                        _ => panic!("Lambda expression did not return boolean values")
+                    }
+                },
+                _ => panic!("Lambda must return boolean values or list of boolean values"),
             },
             None => false,
         });
-
         let bool_mask = BooleanChunked::from_iter_values(self.name().clone(), mask);
         self.filter(&bool_mask)
     }

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -140,10 +140,91 @@ impl LambdaExpression {
                 AnyValue::List(series)
             },
             LambdaExpression::GreaterThan(left, right) => {
-                left.eval_array(args).gt(&right.eval_array(args)).into()
+                // CURRENTLY ONLY SUPPORTS NESTED ARRAYS THAT HAVE A SINGLE MEMBER. 
+                // WITH MULTIPLE MEMBERS WE CAN DECIDE THE LOGIC IF WE ACTUALLY ENCOUNTER THESE CASES.
+                let left_val = left.eval_array(args);
+                let right_val = right.eval_array(args);
+                
+                match (left_val, right_val) {
+                    (AnyValue::List(left_series), AnyValue::List(right_series)) => {
+                        // Both are arrays - compare first values
+                        if left_series.len() > 0 && right_series.len() > 0 {
+                            let left_first = left_series.get(0)
+                                .expect("could not get first value from left array in comparison");
+                            let right_first = right_series.get(0)
+                                .expect("could not get first value from right array in comparison");
+                            left_first.gt(&right_first).into()
+                        } else {
+                            AnyValue::Boolean(false)
+                        }
+                    },
+                    (AnyValue::List(left_series), right) => {
+                        // Left is array, right is scalar
+                        if left_series.len() > 0 {
+                            let left_first = left_series.get(0)
+                                .expect("could not get first value from array in left-array-scalar comparison");
+                            left_first.gt(&right).into()
+                        } else {
+                            AnyValue::Boolean(false)
+                        }
+                    },
+                    (left, AnyValue::List(right_series)) => {
+                        // Left is scalar, right is array
+                        if right_series.len() > 0 {
+                            let right_first = right_series.get(0)
+                                .expect("could not get first value from array in scalar-right-array comparison");
+                            left.gt(&right_first).into()
+                        } else {
+                            AnyValue::Boolean(false)
+                        }
+                    },
+                    // Regular scalar comparison
+                    (left, right) => left.gt(&right).into()
+                }
             },
+            
             LambdaExpression::LessThan(left, right) => {
-                left.eval_array(args).lt(&right.eval_array(args)).into()
+                // CURRENTLY ONLY SUPPORTS NESTED ARRAYS THAT HAVE A SINGLE MEMBER. 
+                // WITH MULTIPLE MEMBERS WE CAN DECIDE THE LOGIC IF WE ACTUALLY ENCOUNTER THESE CASES.
+                let left_val = left.eval_array(args);
+                let right_val = right.eval_array(args);
+                
+                match (left_val, right_val) {
+                    (AnyValue::List(left_series), AnyValue::List(right_series)) => {
+                        // Both are arrays - compare first values
+                        if left_series.len() > 0 && right_series.len() > 0 {
+                            let left_first = left_series.get(0)
+                                .expect("could not get first value from left array in comparison");
+                            let right_first = right_series.get(0)
+                                .expect("could not get first value from right array in comparison");
+                            left_first.lt(&right_first).into()
+                        } else {
+                            AnyValue::Boolean(false)
+                        }
+                    },
+                    (AnyValue::List(left_series), right) => {
+                        // Left is array, right is scalar
+                        if left_series.len() > 0 {
+                            let left_first = left_series.get(0)
+                                .expect("could not get first value from array in left-array-scalar comparison");
+                            left_first.lt(&right).into()
+                        } else {
+                            AnyValue::Boolean(false)
+                        }
+                    },
+                    (left, AnyValue::List(right_series)) => {
+                        // Left is scalar, right is array
+                        if right_series.len() > 0 {
+                            let right_first = right_series.get(0)
+                                .expect("could not get first value from array in scalar-right-array comparison");
+                            left.lt(&right_first).into()
+                        } else {
+                            AnyValue::Boolean(false)
+                        }
+                    },
+                    // Regular scalar comparison
+                    (left, right) => left.lt(&right).into()
+                }
             },
             LambdaExpression::IfThenElse(cond, truthy, falsy) => {
                 if unsafe {

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -140,18 +140,20 @@ impl LambdaExpression {
                 AnyValue::List(series)
             },
             LambdaExpression::GreaterThan(left, right) => {
-                // CURRENTLY ONLY SUPPORTS NESTED ARRAYS THAT HAVE A SINGLE MEMBER. 
+                // CURRENTLY ONLY SUPPORTS NESTED ARRAYS THAT HAVE A SINGLE MEMBER.
                 // WITH MULTIPLE MEMBERS WE CAN DECIDE THE LOGIC IF WE ACTUALLY ENCOUNTER THESE CASES.
                 let left_val = left.eval_array(args);
                 let right_val = right.eval_array(args);
-                
+
                 match (left_val, right_val) {
                     (AnyValue::List(left_series), AnyValue::List(right_series)) => {
                         // Both are arrays - compare first values
                         if left_series.len() > 0 && right_series.len() > 0 {
-                            let left_first = left_series.get(0)
+                            let left_first = left_series
+                                .get(0)
                                 .expect("could not get first value from left array in comparison");
-                            let right_first = right_series.get(0)
+                            let right_first = right_series
+                                .get(0)
                                 .expect("could not get first value from right array in comparison");
                             left_first.gt(&right_first).into()
                         } else {
@@ -179,23 +181,25 @@ impl LambdaExpression {
                         }
                     },
                     // Regular scalar comparison
-                    (left, right) => left.gt(&right).into()
+                    (left, right) => left.gt(&right).into(),
                 }
             },
-            
+
             LambdaExpression::LessThan(left, right) => {
-                // CURRENTLY ONLY SUPPORTS NESTED ARRAYS THAT HAVE A SINGLE MEMBER. 
+                // CURRENTLY ONLY SUPPORTS NESTED ARRAYS THAT HAVE A SINGLE MEMBER.
                 // WITH MULTIPLE MEMBERS WE CAN DECIDE THE LOGIC IF WE ACTUALLY ENCOUNTER THESE CASES.
                 let left_val = left.eval_array(args);
                 let right_val = right.eval_array(args);
-                
+
                 match (left_val, right_val) {
                     (AnyValue::List(left_series), AnyValue::List(right_series)) => {
                         // Both are arrays - compare first values
                         if left_series.len() > 0 && right_series.len() > 0 {
-                            let left_first = left_series.get(0)
+                            let left_first = left_series
+                                .get(0)
                                 .expect("could not get first value from left array in comparison");
-                            let right_first = right_series.get(0)
+                            let right_first = right_series
+                                .get(0)
                                 .expect("could not get first value from right array in comparison");
                             left_first.lt(&right_first).into()
                         } else {
@@ -223,7 +227,7 @@ impl LambdaExpression {
                         }
                     },
                     // Regular scalar comparison
-                    (left, right) => left.lt(&right).into()
+                    (left, right) => left.lt(&right).into(),
                 }
             },
             LambdaExpression::IfThenElse(cond, truthy, falsy) => {

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -259,51 +259,55 @@ pub trait ListNameSpaceImpl: AsList {
         lambda_expressions: Arc<LambdaExpression>,
     ) -> PolarsResult<ListChunked> {
         let ca = self.as_list();
+
         // Apply the filter to each inner list while maintaining outer structure
         let filtered = ca.try_apply_amortized(|s| {
             // Convert AmortizedSeries to Series reference
             let s_ref = s.as_ref();
+
             let filtered_inner: PolarsResult<Series> = match s_ref.dtype() {
+                #[cfg(feature = "dtype-i8")]
                 DataType::Int8 => {
                     let ca = s_ref.i8()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    // Wrap the ChunkedArray in a Series
-                    Ok(Series::new_from_chunked_array("".into(), filtered_ca))
+
+                    Ok(filtered_ca.into_series())
                 },
+                #[cfg(feature = "dtype-i16")]
                 DataType::Int16 => {
                     let ca = s_ref.i16()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(Series::new_from_chunked_array("".into(), filtered_ca))
+                    Ok(filtered_ca.into_series())
                 },
                 DataType::Int32 => {
                     let ca = s_ref.i32()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(Series::new("".into(), filtered_ca))
+                    Ok(filtered_ca.into_series())
                 },
                 DataType::Int64 => {
                     let ca = s_ref.i64()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(Series::new("".into(), filtered_ca))
+                    Ok(filtered_ca.into_series())
                 },
                 DataType::Float32 => {
                     let ca = s_ref.f32()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(Series::new("".into(), filtered_ca))
+                    Ok(filtered_ca.into_series())
                 },
                 DataType::Float64 => {
                     let ca = s_ref.f64()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(Series::new("".into(), filtered_ca))
+                    Ok(filtered_ca.into_series())
                 },
                 DataType::String => {
                     let ca = s_ref.str()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(Series::new("".into(), filtered_ca))
+                    Ok(filtered_ca.into_series())
                 },
                 DataType::List(_) => {
                     let ca = s_ref.list()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(Series::new("".into(), filtered_ca))
+                    Ok(filtered_ca.into_series())
                 },
                 _ => {
                     polars_bail!(
@@ -314,6 +318,7 @@ pub trait ListNameSpaceImpl: AsList {
             };
             filtered_inner
         })?;
+
         Ok(filtered)
     }
 

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -268,12 +268,12 @@ pub trait ListNameSpaceImpl: AsList {
                     let ca = s_ref.i8()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
                     // Wrap the ChunkedArray in a Series
-                    Ok(Series::new("".into(), filtered_ca))
+                    Ok(Series::new_from_chunked_array("".into(), filtered_ca))
                 },
                 DataType::Int16 => {
                     let ca = s_ref.i16()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(Series::new("".into(), filtered_ca))
+                    Ok(Series::new_from_chunked_array("".into(), filtered_ca))
                 },
                 DataType::Int32 => {
                     let ca = s_ref.i32()?;

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -311,7 +311,7 @@ pub trait ListNameSpaceImpl: AsList {
                         ComputeError: "filter_with_func not implemented for type: {:?}",
                         s_ref.dtype()
                     );
-                }
+                },
             };
             filtered_inner
         })?;

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -259,52 +259,51 @@ pub trait ListNameSpaceImpl: AsList {
         lambda_expressions: Arc<LambdaExpression>,
     ) -> PolarsResult<ListChunked> {
         let ca = self.as_list();
-
         // Apply the filter to each inner list while maintaining outer structure
         let filtered = ca.try_apply_amortized(|s| {
             // Convert AmortizedSeries to Series reference
             let s_ref = s.as_ref();
-
             let filtered_inner: PolarsResult<Series> = match s_ref.dtype() {
                 DataType::Int8 => {
                     let ca = s_ref.i8()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(filtered_ca.into_series())
+                    // Wrap the ChunkedArray in a Series
+                    Ok(Series::new("".into(), filtered_ca))
                 },
                 DataType::Int16 => {
                     let ca = s_ref.i16()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(filtered_ca.into_series())
+                    Ok(Series::new("".into(), filtered_ca))
                 },
                 DataType::Int32 => {
                     let ca = s_ref.i32()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(filtered_ca.into_series())
+                    Ok(Series::new("".into(), filtered_ca))
                 },
                 DataType::Int64 => {
                     let ca = s_ref.i64()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(filtered_ca.into_series())
+                    Ok(Series::new("".into(), filtered_ca))
                 },
                 DataType::Float32 => {
                     let ca = s_ref.f32()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(filtered_ca.into_series())
+                    Ok(Series::new("".into(), filtered_ca))
                 },
                 DataType::Float64 => {
                     let ca = s_ref.f64()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(filtered_ca.into_series())
+                    Ok(Series::new("".into(), filtered_ca))
                 },
                 DataType::String => {
                     let ca = s_ref.str()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(filtered_ca.into_series())
+                    Ok(Series::new("".into(), filtered_ca))
                 },
                 DataType::List(_) => {
                     let ca = s_ref.list()?;
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
-                    Ok(filtered_ca.into_series())
+                    Ok(Series::new("".into(), filtered_ca))
                 },
                 _ => {
                     polars_bail!(
@@ -315,7 +314,6 @@ pub trait ListNameSpaceImpl: AsList {
             };
             filtered_inner
         })?;
-
         Ok(filtered)
     }
 

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -254,14 +254,6 @@ pub trait ListNameSpaceImpl: AsList {
         }
     }
 
-    /*
-    fn lst_filter_by_func(&self, lambda_expressions: Arc<LambdaExpression>) -> PolarsResult<ListChunked> {
-        let ca = self.as_list();
-        let bool_mask = ca.filter_with_func(&lambda_expressions)?;
-        Ok(self.same_type(bool_mask))
-    }
-    */
-
     fn lst_filter_by_func(
         &self,
         lambda_expressions: Arc<LambdaExpression>,
@@ -270,11 +262,58 @@ pub trait ListNameSpaceImpl: AsList {
 
         // Apply the filter to each inner list while maintaining outer structure
         let filtered = ca.try_apply_amortized(|s| {
-            // Convert AmortSeries to Series reference for filtering
-            match s.as_ref().filter_with_func(&lambda_expressions) {
-                Ok(filtered_inner) => Ok(filtered_inner),
-                Err(_) => Ok(s.as_ref().clone()), // Keep original on error
-            }
+            // Convert AmortizedSeries to Series reference
+            let s_ref = s.as_ref();
+
+            let filtered_inner: PolarsResult<Series> = match s_ref.dtype() {
+                DataType::Int8 => {
+                    let ca = s_ref.i8()?;
+                    let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
+                    Ok(filtered_ca.into_series())
+                },
+                DataType::Int16 => {
+                    let ca = s_ref.i16()?;
+                    let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
+                    Ok(filtered_ca.into_series())
+                },
+                DataType::Int32 => {
+                    let ca = s_ref.i32()?;
+                    let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
+                    Ok(filtered_ca.into_series())
+                },
+                DataType::Int64 => {
+                    let ca = s_ref.i64()?;
+                    let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
+                    Ok(filtered_ca.into_series())
+                },
+                DataType::Float32 => {
+                    let ca = s_ref.f32()?;
+                    let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
+                    Ok(filtered_ca.into_series())
+                },
+                DataType::Float64 => {
+                    let ca = s_ref.f64()?;
+                    let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
+                    Ok(filtered_ca.into_series())
+                },
+                DataType::String => {
+                    let ca = s_ref.str()?;
+                    let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
+                    Ok(filtered_ca.into_series())
+                },
+                DataType::List(_) => {
+                    let ca = s_ref.list()?;
+                    let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
+                    Ok(filtered_ca.into_series())
+                },
+                _ => {
+                    polars_bail!(
+                        ComputeError: "filter_with_func not implemented for type: {:?}",
+                        s_ref.dtype()
+                    );
+                }
+            };
+            filtered_inner
         })?;
 
         Ok(filtered)


### PR DESCRIPTION
Mostly had issues with nested lists of various sorts. We now support filtering things like [1, 2, 4] or ["ab", "cde", "f"] and support [[1],[2],[3]] but do not support lambda commands of GreaterThan or LesserThan in things like [[1, 2, 3], [4, 5, 6]].

Tested with https://github.com/flarioncode/accelerator/pull/111