### PR TITLE
fix(rust): If `profile` fail due to timeout it should not fail the collect result as well

### DIFF
--- a/crates/polars-error/src/lib.rs
+++ b/crates/polars-error/src/lib.rs
@@ -27,7 +27,7 @@ static ERROR_STRATEGY: LazyLock<ErrorStrategy> = LazyLock::new(|| {
     }
 });
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct ErrString(Cow<'static, str>);
 
 impl ErrString {
@@ -73,7 +73,7 @@ impl Display for ErrString {
     }
 }
 
-#[derive(Debug, thiserror::Error)]
+#[derive(Debug, thiserror::Error, Clone)]
 pub enum PolarsError {
     #[error("not found: {0}")]
     ColumnNotFound(ErrString),

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -763,11 +763,26 @@ impl LazyFrame {
     /// Profile a LazyFrame.
     ///
     /// This will run the query and return a tuple
+    /// containing the materialized DataFrame and a DataFrame that contains profiling information
+    /// of each node that is executed.
+    ///
+    /// The units of the timings are microseconds.
+    pub fn profile(self) -> PolarsResult<(DataFrame, DataFrame)> {
+        let (mut state, mut physical_plan, _) = self.prepare_collect(false)?;
+        state.time_nodes();
+        let out = physical_plan.execute(&mut state)?;
+        let timer_df = state.finish_timer()?;
+        Ok((out, timer_df))
+    }
+
+    /// Profile a LazyFrame.
+    ///
+    /// This will run the query and return a tuple
     /// containing the result of the materialized DataFrame and a result for the DataFrame that contains profiling information
     /// of each node that is executed.
     ///
     /// The units of the timings are microseconds.
-    pub fn profile(self) -> (PolarsResult<DataFrame>, PolarsResult<DataFrame>) {
+    pub fn try_profile(self) -> (PolarsResult<DataFrame>, PolarsResult<DataFrame>) {
         let prepare_collect_res = self.prepare_collect(false);
 
         if let Err(e) = prepare_collect_res {

--- a/crates/polars-lazy/src/frame/mod.rs
+++ b/crates/polars-lazy/src/frame/mod.rs
@@ -763,16 +763,25 @@ impl LazyFrame {
     /// Profile a LazyFrame.
     ///
     /// This will run the query and return a tuple
-    /// containing the materialized DataFrame and a DataFrame that contains profiling information
+    /// containing the result of the materialized DataFrame and a result for the DataFrame that contains profiling information
     /// of each node that is executed.
     ///
     /// The units of the timings are microseconds.
-    pub fn profile(self) -> PolarsResult<(DataFrame, DataFrame)> {
-        let (mut state, mut physical_plan, _) = self.prepare_collect(false)?;
+    pub fn profile(self) -> (PolarsResult<DataFrame>, PolarsResult<DataFrame>) {
+        let prepare_collect_res = self.prepare_collect(false);
+
+        if let Err(e) = prepare_collect_res {
+            return (Err(e.clone()), Err(e));
+        }
+
+        let (mut state, mut physical_plan, _) = prepare_collect_res.unwrap();
         state.time_nodes();
-        let out = physical_plan.execute(&mut state)?;
-        let timer_df = state.finish_timer()?;
-        Ok((out, timer_df))
+
+        let out = physical_plan.execute(&mut state);
+        let timer_df = state.finish_timer();
+
+        // Fix https://github.com/pola-rs/polars/issues/19983
+        (out, timer_df)
     }
 
     /// Stream a query result into a parquet file. This is useful if the final result doesn't fit

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1933,3 +1933,37 @@ fn test_sort_maintain_order_true() -> PolarsResult<()> {
     ]?));
     Ok(())
 }
+
+
+#[test]
+fn when_timers_in_profile_fail_should_not_fail_the_collect() -> PolarsResult<()> {
+    let df = df![
+        "A" => [None, Some(1)],
+    ]?
+        .lazy();
+
+    let polars_plan = df
+        //
+        .lazy()
+        .filter(col("A").is_not_null());
+
+    let (collect_result, time_result) = polars_plan.profile();
+
+    match (&collect_result, &time_result) {
+
+        // Should fail the time result
+        (_, Ok(_)) => {
+            Err(PolarsError::ComputeError("Expected the time result to fail".into()))
+        }
+
+        // Should not fail the collect result
+        (Err(_), Err(_)) => {
+            collect_result.map(|_| ())
+        }
+
+        // Should only fail the time result
+        (Ok(_), Err(_)) => {
+            Ok(())
+        }
+    }
+}

--- a/crates/polars-lazy/src/tests/queries.rs
+++ b/crates/polars-lazy/src/tests/queries.rs
@@ -1934,36 +1934,30 @@ fn test_sort_maintain_order_true() -> PolarsResult<()> {
     Ok(())
 }
 
-
 #[test]
 fn when_timers_in_profile_fail_should_not_fail_the_collect() -> PolarsResult<()> {
     let df = df![
         "A" => [None, Some(1)],
     ]?
-        .lazy();
+    .lazy();
 
     let polars_plan = df
         //
         .lazy()
         .filter(col("A").is_not_null());
 
-    let (collect_result, time_result) = polars_plan.profile();
+    let (collect_result, time_result) = polars_plan.try_profile();
 
     match (&collect_result, &time_result) {
-
         // Should fail the time result
-        (_, Ok(_)) => {
-            Err(PolarsError::ComputeError("Expected the time result to fail".into()))
-        }
+        (_, Ok(_)) => Err(PolarsError::ComputeError(
+            "Expected the time result to fail".into(),
+        )),
 
         // Should not fail the collect result
-        (Err(_), Err(_)) => {
-            collect_result.map(|_| ())
-        }
+        (Err(_), Err(_)) => collect_result.map(|_| ()),
 
         // Should only fail the time result
-        (Ok(_), Err(_)) => {
-            Ok(())
-        }
+        (Ok(_), Err(_)) => Ok(()),
     }
 }


### PR DESCRIPTION
Ref: https://github.com/pola-rs/polars/issues/19983