### PR TITLE
feat: Add support for float types and string in polars to use in lambdas

### DIFF
--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -368,8 +368,12 @@ macro_rules! impl_dyn_series {
             fn as_any(&self) -> &dyn Any {
                 &self.0
             }
-            
-            fn sort_with_func(&self, _options: SortOptions, _lambda: &LambdaExpression) -> PolarsResult<Series> {
+
+            fn sort_with_func(
+                &self,
+                _options: SortOptions,
+                _lambda: &LambdaExpression,
+            ) -> PolarsResult<Series> {
                 Ok(ChunkSort::sort_with_func(&self.0, _options, _lambda).into_series())
             }
         }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -368,6 +368,10 @@ macro_rules! impl_dyn_series {
             fn as_any(&self) -> &dyn Any {
                 &self.0
             }
+            
+            fn sort_with_func(&self, _options: SortOptions, _lambda: &LambdaExpression) -> PolarsResult<Series> {
+                Ok(ChunkSort::sort_with_func(&self.0, _options, _lambda).into_series())
+            }
         }
     };
 }

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -151,7 +151,11 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
         ChunkTransform::transform(&self.0, lambda)
     }
 
-    fn sort_with_func(&self, _options: SortOptions, _lambda: &LambdaExpression) -> PolarsResult<Series> {
+    fn sort_with_func(
+        &self,
+        _options: SortOptions,
+        _lambda: &LambdaExpression,
+    ) -> PolarsResult<Series> {
         Ok(ChunkSort::sort_with_func(&self.0, _options, _lambda).into_series())
     }
 

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -151,6 +151,10 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
         ChunkTransform::transform(&self.0, lambda)
     }
 
+    fn sort_with_func(&self, _options: SortOptions, _lambda: &LambdaExpression) -> PolarsResult<Series> {
+        Ok(ChunkSort::sort_with_func(&self.0, _options, _lambda).into_series())
+    }
+
     fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
         Ok(self.0.take(indices)?.into_series())
     }


### PR DESCRIPTION
add sort_with_func() implementation for floats types and strings. so we could use array_sort() with those types in lambda expressions.