### PR TITLE
fix(rust): Fix module and divide + rename feature to `consistent_arithmetic`

### DIFF
--- a/crates/polars-compute/Cargo.toml
+++ b/crates/polars-compute/Cargo.toml
@@ -27,4 +27,4 @@ version_check = { workspace = true }
 nightly = []
 simd = ["arrow/simd"]
 dtype-array = []
-consistent_division = []
+consistent_arithmetic = []

--- a/crates/polars-compute/src/arithmetic/float.rs
+++ b/crates/polars-compute/src/arithmetic/float.rs
@@ -105,12 +105,12 @@ macro_rules! impl_float_arith_kernel {
             }
 
             fn prim_true_div_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<Self::TrueDivT> {
-                #[cfg(feature = "consistent_division")]
+                #[cfg(feature = "consistent_arithmetic")]
                 {
                     // Fixes: https://github.com/pola-rs/polars/issues/20038
                     prim_unary_values(lhs, |x| x / rhs)
                 }
-                #[cfg(not(feature = "consistent_division"))]
+                #[cfg(not(feature = "consistent_arithmetic"))]
                 {
                     Self::prim_wrapping_mul_scalar(lhs, 1.0 / rhs)
                 }

--- a/crates/polars-compute/src/arithmetic/float.rs
+++ b/crates/polars-compute/src/arithmetic/float.rs
@@ -37,7 +37,15 @@ macro_rules! impl_float_arith_kernel {
             }
 
             fn prim_wrapping_mod(lhs: PArr<$T>, rhs: PArr<$T>) -> PArr<$T> {
-                prim_binary_values(lhs, rhs, |l, r| l - r * (l / r).floor())
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    prim_binary_values(lhs, rhs, |l, r| l % r)
+                }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    prim_binary_values(lhs, rhs, |l, r| l - r * (l / r).floor())
+                }
             }
 
             fn prim_wrapping_add_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
@@ -92,12 +100,28 @@ macro_rules! impl_float_arith_kernel {
             }
 
             fn prim_wrapping_mod_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
-                let inv = 1.0 / rhs;
-                prim_unary_values(lhs, |x| x - rhs * (x * inv).floor())
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    prim_unary_values(lhs, |x| x % rhs)
+                }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    let inv = 1.0 / rhs;
+                    prim_unary_values(lhs, |x| x - rhs * (x * inv).floor())
+                }
             }
 
             fn prim_wrapping_mod_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
-                prim_unary_values(rhs, |x| lhs - x * (lhs / x).floor())
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    prim_unary_values(rhs, |x| lhs % x)
+                }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    prim_unary_values(rhs, |x| lhs - x * (lhs / x).floor())
+                }
             }
 
             fn prim_true_div(lhs: PArr<$T>, rhs: PArr<$T>) -> PArr<Self::TrueDivT> {

--- a/crates/polars-compute/src/arithmetic/signed.rs
+++ b/crates/polars-compute/src/arithmetic/signed.rs
@@ -77,7 +77,9 @@ macro_rules! impl_signed_arith_kernel {
                 }
                 #[cfg(not(feature = "consistent_arithmetic"))]
                 {
-                    ret = prim_binary_values(lhs, other, |lhs, rhs| lhs.wrapping_floor_div_mod(rhs).1);
+                    ret = prim_binary_values(lhs, other, |lhs, rhs| {
+                        lhs.wrapping_floor_div_mod(rhs).1
+                    });
                 }
 
                 ret.with_validity(valid)
@@ -220,7 +222,6 @@ macro_rules! impl_signed_arith_kernel {
                         })
                     }
                 }
-
             }
 
             fn prim_wrapping_mod_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {

--- a/crates/polars-compute/src/arithmetic/signed.rs
+++ b/crates/polars-compute/src/arithmetic/signed.rs
@@ -227,7 +227,22 @@ macro_rules! impl_signed_arith_kernel {
 
                 let mask = rhs.tot_ne_kernel_broadcast(&0);
                 let valid = combine_validities_and(rhs.validity(), Some(&mask));
-                let ret = prim_unary_values(rhs, |x| lhs.wrapping_floor_div_mod(x).1);
+
+                let ret;
+                 #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    ret = prim_unary_values(rhs, |x| if x != 0 {
+                        lhs % x
+                    } else {
+                        0
+                    });
+                }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    ret = prim_unary_values(rhs, |x| lhs.wrapping_floor_div_mod(x).1);
+                }
+
                 ret.with_validity(valid)
             }
 

--- a/crates/polars-compute/src/arithmetic/signed.rs
+++ b/crates/polars-compute/src/arithmetic/signed.rs
@@ -73,11 +73,11 @@ macro_rules! impl_signed_arith_kernel {
                 #[cfg(feature = "consistent_arithmetic")]
                 {
                     // Fixes: https://github.com/pola-rs/polars/issues/20038
-                    ret = prim_binary_values(lhs, other, |lhs, rhs| if rhs != 0 {
-                        lhs % rhs
-                    } else {
-                        0
-                    });
+                    ret = prim_binary_values(
+                        lhs,
+                        other,
+                        |lhs, rhs| if rhs != 0 { lhs % rhs } else { 0 },
+                    );
                 }
                 #[cfg(not(feature = "consistent_arithmetic"))]
                 {
@@ -241,14 +241,10 @@ macro_rules! impl_signed_arith_kernel {
                 let valid = combine_validities_and(rhs.validity(), Some(&mask));
 
                 let ret;
-                 #[cfg(feature = "consistent_arithmetic")]
+                #[cfg(feature = "consistent_arithmetic")]
                 {
                     // Fixes: https://github.com/pola-rs/polars/issues/20038
-                    ret = prim_unary_values(rhs, |x| if x != 0 {
-                        lhs % x
-                    } else {
-                        0
-                    });
+                    ret = prim_unary_values(rhs, |x| if x != 0 { lhs % x } else { 0 });
                 }
                 #[cfg(not(feature = "consistent_arithmetic"))]
                 {

--- a/crates/polars-compute/src/arithmetic/signed.rs
+++ b/crates/polars-compute/src/arithmetic/signed.rs
@@ -68,20 +68,8 @@ macro_rules! impl_signed_arith_kernel {
                     other.take_validity().as_ref(), // compute combination twice.
                     Some(&mask),
                 );
-
-                let ret;
-                #[cfg(feature = "consistent_arithmetic")]
-                {
-                    // Fixes: https://github.com/pola-rs/polars/issues/20038
-                    ret = prim_binary_values(lhs, other, |lhs, rhs| lhs % rhs);
-                }
-                #[cfg(not(feature = "consistent_arithmetic"))]
-                {
-                    ret = prim_binary_values(lhs, other, |lhs, rhs| {
-                        lhs.wrapping_floor_div_mod(rhs).1
-                    });
-                }
-
+                let ret =
+                    prim_binary_values(lhs, other, |lhs, rhs| lhs.wrapping_floor_div_mod(rhs).1);
                 ret.with_validity(valid)
             }
 
@@ -188,59 +176,43 @@ macro_rules! impl_signed_arith_kernel {
             }
 
             fn prim_wrapping_mod_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
-                #[cfg(feature = "consistent_arithmetic")]
-                {
-                    // Fixes: https://github.com/pola-rs/polars/issues/20038
-                    prim_unary_values(lhs, |x| x % rhs)
-                }
-                #[cfg(not(feature = "consistent_arithmetic"))]
-                {
-                    if rhs == 0 {
-                        PArr::full_null(lhs.len(), lhs.dtype().clone())
-                    } else if rhs == -1 || rhs == 1 {
-                        lhs.fill_with(0)
-                    } else {
-                        let scalar_u = rhs.unsigned_abs();
-                        let red = <$StrRed>::new(scalar_u);
-                        prim_unary_values(lhs, |x| {
-                            // Remainder fits in signed type after reduction.
-                            // Largest possible modulo -I::MIN, with
-                            // -I::MIN-1 == I::MAX as largest remainder.
-                            let mut rem_u = x.unsigned_abs() % red;
+                if rhs == 0 {
+                    PArr::full_null(lhs.len(), lhs.dtype().clone())
+                } else if rhs == -1 || rhs == 1 {
+                    lhs.fill_with(0)
+                } else {
+                    let scalar_u = rhs.unsigned_abs();
+                    let red = <$StrRed>::new(scalar_u);
+                    prim_unary_values(lhs, |x| {
+                        // Remainder fits in signed type after reduction.
+                        // Largest possible modulo -I::MIN, with
+                        // -I::MIN-1 == I::MAX as largest remainder.
+                        let mut rem_u = x.unsigned_abs() % red;
 
-                            // Mixed signs: swap direction of remainder.
-                            if rem_u != 0 && (rhs < 0) != (x < 0) {
-                                rem_u = scalar_u - rem_u;
-                            }
+                        // Mixed signs: swap direction of remainder.
+                        if rem_u != 0 && (rhs < 0) != (x < 0) {
+                            rem_u = scalar_u - rem_u;
+                        }
 
-                            // Remainder should have sign of RHS.
-                            if rhs < 0 {
-                                -(rem_u as $T)
-                            } else {
-                                rem_u as $T
-                            }
-                        })
-                    }
+                        // Remainder should have sign of RHS.
+                        if rhs < 0 {
+                            -(rem_u as $T)
+                        } else {
+                            rem_u as $T
+                        }
+                    })
                 }
             }
 
             fn prim_wrapping_mod_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
-                #[cfg(feature = "consistent_arithmetic")]
-                {
-                    // Fixes: https://github.com/pola-rs/polars/issues/20038
-                    prim_unary_values(rhs, |x| lhs % x)
+                if lhs == 0 {
+                    return rhs.fill_with(0);
                 }
-                #[cfg(not(feature = "consistent_arithmetic"))]
-                {
-                    if lhs == 0 {
-                        return rhs.fill_with(0);
-                    }
 
-                    let mask = rhs.tot_ne_kernel_broadcast(&0);
-                    let valid = combine_validities_and(rhs.validity(), Some(&mask));
-                    let ret = prim_unary_values(rhs, |x| lhs.wrapping_floor_div_mod(x).1);
-                    ret.with_validity(valid)
-                }
+                let mask = rhs.tot_ne_kernel_broadcast(&0);
+                let valid = combine_validities_and(rhs.validity(), Some(&mask));
+                let ret = prim_unary_values(rhs, |x| lhs.wrapping_floor_div_mod(x).1);
+                ret.with_validity(valid)
             }
 
             fn prim_true_div(lhs: PArr<$T>, other: PArr<$T>) -> PArr<Self::TrueDivT> {

--- a/crates/polars-compute/src/arithmetic/signed.rs
+++ b/crates/polars-compute/src/arithmetic/signed.rs
@@ -68,8 +68,24 @@ macro_rules! impl_signed_arith_kernel {
                     other.take_validity().as_ref(), // compute combination twice.
                     Some(&mask),
                 );
-                let ret =
-                    prim_binary_values(lhs, other, |lhs, rhs| lhs.wrapping_floor_div_mod(rhs).1);
+
+                let ret;
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    ret = prim_binary_values(lhs, other, |lhs, rhs| if rhs != 0 {
+                        lhs % rhs
+                    } else {
+                        0
+                    });
+                }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    ret = prim_binary_values(lhs, other, |lhs, rhs| {
+                        lhs.wrapping_floor_div_mod(rhs).1
+                    });
+                }
+
                 ret.with_validity(valid)
             }
 

--- a/crates/polars-compute/src/arithmetic/signed.rs
+++ b/crates/polars-compute/src/arithmetic/signed.rs
@@ -210,11 +210,23 @@ macro_rules! impl_signed_arith_kernel {
                             rem_u = scalar_u - rem_u;
                         }
 
-                        // Remainder should have sign of RHS.
-                        if rhs < 0 {
-                            -(rem_u as $T)
-                        } else {
-                            rem_u as $T
+                        #[cfg(feature = "consistent_arithmetic")]
+                        {
+                            // Module should have sign of LHS.
+                            if x < 0 {
+                                -(rem_u as $T)
+                            } else {
+                                rem_u as $T
+                            }
+                        }
+                        #[cfg(not(feature = "consistent_arithmetic"))]
+                        {
+                            // Remainder should have sign of RHS.
+                            if rhs < 0 {
+                                -(rem_u as $T)
+                            } else {
+                                rem_u as $T
+                            }
                         }
                     })
                 }

--- a/crates/polars-compute/src/arithmetic/signed.rs
+++ b/crates/polars-compute/src/arithmetic/signed.rs
@@ -68,8 +68,18 @@ macro_rules! impl_signed_arith_kernel {
                     other.take_validity().as_ref(), // compute combination twice.
                     Some(&mask),
                 );
-                let ret =
-                    prim_binary_values(lhs, other, |lhs, rhs| lhs.wrapping_floor_div_mod(rhs).1);
+
+                let ret;
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    ret = prim_binary_values(lhs, other, |lhs, rhs| lhs % rhs);
+                }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    ret = prim_binary_values(lhs, other, |lhs, rhs| lhs.wrapping_floor_div_mod(rhs).1);
+                }
+
                 ret.with_validity(valid)
             }
 
@@ -176,43 +186,60 @@ macro_rules! impl_signed_arith_kernel {
             }
 
             fn prim_wrapping_mod_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
-                if rhs == 0 {
-                    PArr::full_null(lhs.len(), lhs.dtype().clone())
-                } else if rhs == -1 || rhs == 1 {
-                    lhs.fill_with(0)
-                } else {
-                    let scalar_u = rhs.unsigned_abs();
-                    let red = <$StrRed>::new(scalar_u);
-                    prim_unary_values(lhs, |x| {
-                        // Remainder fits in signed type after reduction.
-                        // Largest possible modulo -I::MIN, with
-                        // -I::MIN-1 == I::MAX as largest remainder.
-                        let mut rem_u = x.unsigned_abs() % red;
-
-                        // Mixed signs: swap direction of remainder.
-                        if rem_u != 0 && (rhs < 0) != (x < 0) {
-                            rem_u = scalar_u - rem_u;
-                        }
-
-                        // Remainder should have sign of RHS.
-                        if rhs < 0 {
-                            -(rem_u as $T)
-                        } else {
-                            rem_u as $T
-                        }
-                    })
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    prim_unary_values(lhs, |x| x % rhs)
                 }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    if rhs == 0 {
+                        PArr::full_null(lhs.len(), lhs.dtype().clone())
+                    } else if rhs == -1 || rhs == 1 {
+                        lhs.fill_with(0)
+                    } else {
+                        let scalar_u = rhs.unsigned_abs();
+                        let red = <$StrRed>::new(scalar_u);
+                        prim_unary_values(lhs, |x| {
+                            // Remainder fits in signed type after reduction.
+                            // Largest possible modulo -I::MIN, with
+                            // -I::MIN-1 == I::MAX as largest remainder.
+                            let mut rem_u = x.unsigned_abs() % red;
+
+                            // Mixed signs: swap direction of remainder.
+                            if rem_u != 0 && (rhs < 0) != (x < 0) {
+                                rem_u = scalar_u - rem_u;
+                            }
+
+                            // Remainder should have sign of RHS.
+                            if rhs < 0 {
+                                -(rem_u as $T)
+                            } else {
+                                rem_u as $T
+                            }
+                        })
+                    }
+                }
+
             }
 
             fn prim_wrapping_mod_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
-                if lhs == 0 {
-                    return rhs.fill_with(0);
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    prim_unary_values(rhs, |x| lhs % x)
                 }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    if lhs == 0 {
+                        return rhs.fill_with(0);
+                    }
 
-                let mask = rhs.tot_ne_kernel_broadcast(&0);
-                let valid = combine_validities_and(rhs.validity(), Some(&mask));
-                let ret = prim_unary_values(rhs, |x| lhs.wrapping_floor_div_mod(x).1);
-                ret.with_validity(valid)
+                    let mask = rhs.tot_ne_kernel_broadcast(&0);
+                    let valid = combine_validities_and(rhs.validity(), Some(&mask));
+                    let ret = prim_unary_values(rhs, |x| lhs.wrapping_floor_div_mod(x).1);
+                    ret.with_validity(valid)
+                }
             }
 
             fn prim_true_div(lhs: PArr<$T>, other: PArr<$T>) -> PArr<Self::TrueDivT> {
@@ -220,8 +247,17 @@ macro_rules! impl_signed_arith_kernel {
             }
 
             fn prim_true_div_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<Self::TrueDivT> {
-                let inv = 1.0 / rhs as f64;
-                prim_unary_values(lhs, |x| x as f64 * inv)
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    let rhs = rhs as f64;
+                    prim_unary_values(lhs, |x| x as f64 / rhs)
+                }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    let inv = 1.0 / rhs as f64;
+                    prim_unary_values(lhs, |x| x as f64 * inv)
+                }
             }
 
             fn prim_true_div_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<Self::TrueDivT> {

--- a/crates/polars-compute/src/arithmetic/unsigned.rs
+++ b/crates/polars-compute/src/arithmetic/unsigned.rs
@@ -53,7 +53,18 @@ macro_rules! impl_unsigned_arith_kernel {
                     other.take_validity().as_ref(), // compute combination twice.
                     Some(&mask),
                 );
-                let ret = prim_binary_values(lhs, other, |a, b| if b != 0 { a % b } else { 0 });
+
+                let res;
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    ret = prim_binary_values(lhs, other, |a, b| a % b);
+                }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    ret = prim_binary_values(lhs, other, |a, b| if b != 0 { a % b } else { 0 });
+                }
+
                 ret.with_validity(valid)
             }
 
@@ -114,25 +125,41 @@ macro_rules! impl_unsigned_arith_kernel {
             }
 
             fn prim_wrapping_mod_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
-                if rhs == 0 {
-                    PArr::full_null(lhs.len(), lhs.dtype().clone())
-                } else if rhs == 1 {
-                    lhs.fill_with(0)
-                } else {
-                    let red = <$StrRed>::new(rhs);
-                    prim_unary_values(lhs, |x| x % red)
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    prim_unary_values(lhs, |x| x % rhs)
+                }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    if rhs == 0 {
+                        PArr::full_null(lhs.len(), lhs.dtype().clone())
+                    } else if rhs == 1 {
+                        lhs.fill_with(0)
+                    } else {
+                        let red = <$StrRed>::new(rhs);
+                        prim_unary_values(lhs, |x| x % red)
+                    }
                 }
             }
 
             fn prim_wrapping_mod_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
-                if lhs == 0 {
-                    return rhs.fill_with(0);
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    prim_unary_values(rhs, |x| lhs % x)
                 }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    if lhs == 0 {
+                        return rhs.fill_with(0);
+                    }
 
-                let mask = rhs.tot_ne_kernel_broadcast(&0);
-                let valid = combine_validities_and(rhs.validity(), Some(&mask));
-                let ret = prim_unary_values(rhs, |x| if x != 0 { lhs % x } else { 0 });
-                ret.with_validity(valid)
+                    let mask = rhs.tot_ne_kernel_broadcast(&0);
+                    let valid = combine_validities_and(rhs.validity(), Some(&mask));
+                    let ret = prim_unary_values(rhs, |x| if x != 0 { lhs % x } else { 0 });
+                    ret.with_validity(valid)
+                }
             }
 
             fn prim_true_div(lhs: PArr<$T>, other: PArr<$T>) -> PArr<Self::TrueDivT> {
@@ -140,8 +167,17 @@ macro_rules! impl_unsigned_arith_kernel {
             }
 
             fn prim_true_div_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<Self::TrueDivT> {
-                let inv = 1.0 / rhs as f64;
-                prim_unary_values(lhs, |x| x as f64 * inv)
+                #[cfg(feature = "consistent_arithmetic")]
+                {
+                    // Fixes: https://github.com/pola-rs/polars/issues/20038
+                    let rhs = rhs as f64;
+                    prim_unary_values(lhs, |x| x as f64 / rhs)
+                }
+                #[cfg(not(feature = "consistent_arithmetic"))]
+                {
+                    let inv = 1.0 / rhs as f64;
+                    prim_unary_values(lhs, |x| x as f64 * inv)
+                }
             }
 
             fn prim_true_div_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<Self::TrueDivT> {

--- a/crates/polars-compute/src/arithmetic/unsigned.rs
+++ b/crates/polars-compute/src/arithmetic/unsigned.rs
@@ -54,7 +54,7 @@ macro_rules! impl_unsigned_arith_kernel {
                     Some(&mask),
                 );
 
-                let res;
+                let ret;
                 #[cfg(feature = "consistent_arithmetic")]
                 {
                     // Fixes: https://github.com/pola-rs/polars/issues/20038

--- a/crates/polars-compute/src/arithmetic/unsigned.rs
+++ b/crates/polars-compute/src/arithmetic/unsigned.rs
@@ -53,18 +53,7 @@ macro_rules! impl_unsigned_arith_kernel {
                     other.take_validity().as_ref(), // compute combination twice.
                     Some(&mask),
                 );
-
-                let ret;
-                #[cfg(feature = "consistent_arithmetic")]
-                {
-                    // Fixes: https://github.com/pola-rs/polars/issues/20038
-                    ret = prim_binary_values(lhs, other, |a, b| a % b);
-                }
-                #[cfg(not(feature = "consistent_arithmetic"))]
-                {
-                    ret = prim_binary_values(lhs, other, |a, b| if b != 0 { a % b } else { 0 });
-                }
-
+                let ret = prim_binary_values(lhs, other, |a, b| if b != 0 { a % b } else { 0 });
                 ret.with_validity(valid)
             }
 
@@ -125,41 +114,25 @@ macro_rules! impl_unsigned_arith_kernel {
             }
 
             fn prim_wrapping_mod_scalar(lhs: PArr<$T>, rhs: $T) -> PArr<$T> {
-                #[cfg(feature = "consistent_arithmetic")]
-                {
-                    // Fixes: https://github.com/pola-rs/polars/issues/20038
-                    prim_unary_values(lhs, |x| x % rhs)
-                }
-                #[cfg(not(feature = "consistent_arithmetic"))]
-                {
-                    if rhs == 0 {
-                        PArr::full_null(lhs.len(), lhs.dtype().clone())
-                    } else if rhs == 1 {
-                        lhs.fill_with(0)
-                    } else {
-                        let red = <$StrRed>::new(rhs);
-                        prim_unary_values(lhs, |x| x % red)
-                    }
+                if rhs == 0 {
+                    PArr::full_null(lhs.len(), lhs.dtype().clone())
+                } else if rhs == 1 {
+                    lhs.fill_with(0)
+                } else {
+                    let red = <$StrRed>::new(rhs);
+                    prim_unary_values(lhs, |x| x % red)
                 }
             }
 
             fn prim_wrapping_mod_scalar_lhs(lhs: $T, rhs: PArr<$T>) -> PArr<$T> {
-                #[cfg(feature = "consistent_arithmetic")]
-                {
-                    // Fixes: https://github.com/pola-rs/polars/issues/20038
-                    prim_unary_values(rhs, |x| lhs % x)
+                if lhs == 0 {
+                    return rhs.fill_with(0);
                 }
-                #[cfg(not(feature = "consistent_arithmetic"))]
-                {
-                    if lhs == 0 {
-                        return rhs.fill_with(0);
-                    }
 
-                    let mask = rhs.tot_ne_kernel_broadcast(&0);
-                    let valid = combine_validities_and(rhs.validity(), Some(&mask));
-                    let ret = prim_unary_values(rhs, |x| if x != 0 { lhs % x } else { 0 });
-                    ret.with_validity(valid)
-                }
+                let mask = rhs.tot_ne_kernel_broadcast(&0);
+                let valid = combine_validities_and(rhs.validity(), Some(&mask));
+                let ret = prim_unary_values(rhs, |x| if x != 0 { lhs % x } else { 0 });
+                ret.with_validity(valid)
             }
 
             fn prim_true_div(lhs: PArr<$T>, other: PArr<$T>) -> PArr<Self::TrueDivT> {

--- a/crates/polars-core/Cargo.toml
+++ b/crates/polars-core/Cargo.toml
@@ -47,7 +47,7 @@ serde_json = { workspace = true }
 version_check = { workspace = true }
 
 [features]
-consistent_division = ["polars-compute/consistent_division"]
+consistent_arithmetic = ["polars-compute/consistent_arithmetic"]
 simd = ["arrow/simd", "polars-compute/simd"]
 nightly = ["simd", "hashbrown/nightly", "polars-utils/nightly", "arrow/nightly"]
 avx512 = []

--- a/crates/polars/Cargo.toml
+++ b/crates/polars/Cargo.toml
@@ -47,7 +47,7 @@ version_check = { workspace = true }
 getrandom = { version = "0.2", features = ["js"] }
 
 [features]
-consistent_division = ["polars-core/consistent_division"]
+consistent_arithmetic = ["polars-core/consistent_arithmetic"]
 sql = ["polars-sql"]
 rows = ["polars-core/rows"]
 simd = ["polars-core/simd", "polars-io/simd", "polars-ops?/simd"]


### PR DESCRIPTION
Changes:
1. Rename feature from `consistent_division` to `consistent_arithmetic`
2. fix `%` to be consistent with Rust and Java `%` module
3. fix divide for integer as well