### PR TITLE
feat: Add support for float types and string in polars to use in lambdas

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -32,6 +32,7 @@ pub enum LambdaExpression {
     Substring(Box<Self>, Box<Self>, Box<Self>),
     Instr(Box<Self>, Box<Self>),
     Add(Box<Self>, Box<Self>),
+    IsNull(Box<Self>),
 }
 
 impl Eq for LambdaExpression {}
@@ -81,6 +82,7 @@ impl Hash for LambdaExpression {
                 first.hash(state);
                 second.hash(state);
             },
+            LambdaExpression::IsNull(v) => v.hash(state),
         }
     }
 }
@@ -283,6 +285,13 @@ impl LambdaExpression {
                 let right = right.eval_array(args);
                 left.add(&right.cast(&left.dtype()))
             },
+            LambdaExpression::IsNull(expr) => {
+                if expr.eval_array(args).is_null() {
+                    AnyValue::Boolean(true)
+                } else {
+                    AnyValue::Boolean(false)
+                }
+            }
         }
     }
 
@@ -358,6 +367,13 @@ impl LambdaExpression {
                 let right = right.eval_numeric::<T>(args);
                 left.add(&right.cast(&left.dtype()))
             },
+            LambdaExpression::IsNull(expr) => {
+                if expr.eval_numeric::<T>(args).is_null() {
+                    AnyValue::Boolean(true)
+                } else {
+                    AnyValue::Boolean(false)
+                }
+            }
         }
     }
 
@@ -433,6 +449,13 @@ impl LambdaExpression {
                 let right = right.eval_bool(args);
                 left.add(&right.cast(&left.dtype()))
             },
+            LambdaExpression::IsNull(expr) => {
+                if expr.eval_bool(args).is_null() {
+                    AnyValue::Boolean(true)
+                } else {
+                    AnyValue::Boolean(false)
+                }
+            }
         }
     }
 
@@ -511,6 +534,13 @@ impl LambdaExpression {
                 let right = right.eval_slice(args);
                 left.add(&right.cast(&left.dtype()))
             },
+            LambdaExpression::IsNull(expr) => {
+                if expr.eval_slice(args).is_null() {
+                    AnyValue::Boolean(true)
+                } else {
+                    AnyValue::Boolean(false)
+                }
+            }
         }
     }
 
@@ -588,6 +618,13 @@ impl LambdaExpression {
                 let right = right.eval_any(args);
                 left.add(&right.cast(&left.dtype()))
             },
+            LambdaExpression::IsNull(expr) => {
+                if expr.eval_any(args).is_null() {
+                    AnyValue::Boolean(true)
+                } else {
+                    AnyValue::Boolean(false)
+                }
+            }
         }
     }
 
@@ -622,6 +659,7 @@ impl LambdaExpression {
             LambdaExpression::Substring(s, _, _) => s.return_type(), // substring is used for string and byte arrays
             LambdaExpression::Instr(_, _) => Some(DataType::Int32),
             LambdaExpression::Add(left, _) => left.return_type(),
+            LambdaExpression::IsNull(_) => Some(DataType::Boolean),
         }
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -291,7 +291,7 @@ impl LambdaExpression {
                 } else {
                     AnyValue::Boolean(false)
                 }
-            }
+            },
         }
     }
 
@@ -373,7 +373,7 @@ impl LambdaExpression {
                 } else {
                     AnyValue::Boolean(false)
                 }
-            }
+            },
         }
     }
 
@@ -455,7 +455,7 @@ impl LambdaExpression {
                 } else {
                     AnyValue::Boolean(false)
                 }
-            }
+            },
         }
     }
 
@@ -540,7 +540,7 @@ impl LambdaExpression {
                 } else {
                     AnyValue::Boolean(false)
                 }
-            }
+            },
         }
     }
 
@@ -624,7 +624,7 @@ impl LambdaExpression {
                 } else {
                     AnyValue::Boolean(false)
                 }
-            }
+            },
         }
     }
 

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -368,8 +368,12 @@ macro_rules! impl_dyn_series {
             fn as_any(&self) -> &dyn Any {
                 &self.0
             }
-            
-            fn sort_with_func(&self, _options: SortOptions, _lambda: &LambdaExpression) -> PolarsResult<Series> {
+
+            fn sort_with_func(
+                &self,
+                _options: SortOptions,
+                _lambda: &LambdaExpression,
+            ) -> PolarsResult<Series> {
                 Ok(ChunkSort::sort_with_func(&self.0, _options, _lambda).into_series())
             }
         }

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -368,6 +368,10 @@ macro_rules! impl_dyn_series {
             fn as_any(&self) -> &dyn Any {
                 &self.0
             }
+            
+            fn sort_with_func(&self, _options: SortOptions, _lambda: &LambdaExpression) -> PolarsResult<Series> {
+                Ok(ChunkSort::sort_with_func(&self.0, _options, _lambda).into_series())
+            }
         }
     };
 }

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -151,7 +151,11 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
         ChunkTransform::transform(&self.0, lambda)
     }
 
-    fn sort_with_func(&self, _options: SortOptions, _lambda: &LambdaExpression) -> PolarsResult<Series> {
+    fn sort_with_func(
+        &self,
+        _options: SortOptions,
+        _lambda: &LambdaExpression,
+    ) -> PolarsResult<Series> {
         Ok(ChunkSort::sort_with_func(&self.0, _options, _lambda).into_series())
     }
 

--- a/crates/polars-core/src/series/implementations/string.rs
+++ b/crates/polars-core/src/series/implementations/string.rs
@@ -151,6 +151,10 @@ impl SeriesTrait for SeriesWrap<StringChunked> {
         ChunkTransform::transform(&self.0, lambda)
     }
 
+    fn sort_with_func(&self, _options: SortOptions, _lambda: &LambdaExpression) -> PolarsResult<Series> {
+        Ok(ChunkSort::sort_with_func(&self.0, _options, _lambda).into_series())
+    }
+
     fn take(&self, indices: &IdxCa) -> PolarsResult<Series> {
         Ok(self.0.take(indices)?.into_series())
     }


### PR DESCRIPTION
This PR adds underling support for strings and floats in lambda expressions