### PR TITLE
fix(rust): String fixes - only trim direct spaces and do not split \r and \n

### DIFF
--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -192,13 +192,16 @@ mod tests {
     #[test]
     fn test_dot_pattern_splitting() {
         let input = create_string_chunked("input", vec![Some("a\rb\rc\nd\te")]);
-        
+
         let result = flarion_split_helper(&input, ".", -1).unwrap().into_series();
-        
+
         assert_eq!(result.len(), 1);
         assert_eq!(
             result.get(0).unwrap(),
-            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["", "\r", "", "\r", "", "\n", "", "", ""]))
+            AnyValue::List(Series::new(
+                PlSmallStr::EMPTY,
+                &["", "\r", "", "\r", "", "\n", "", "", ""]
+            ))
         );
     }
 }

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -43,7 +43,15 @@ pub fn flarion_split_helper(
             });
         };
     } else {
-        let re = RegexBuilder::new(pattern)
+        // Special handling for "." pattern to match Spark behavior
+        let pattern = if pattern == "." {
+            // Match any character except \r and \n
+            "[^\\r\\n]"
+        } else {
+            pattern
+        };
+
+        let re = RegexBuilder::new(&pattern)
             .size_limit(30 * 1024 * 1024)
             .build()?;
 
@@ -178,6 +186,19 @@ mod tests {
         assert_eq!(
             result.get(0).unwrap(),
             AnyValue::List(Series::new(PlSmallStr::EMPTY, &[""]))
+        );
+    }
+
+    #[test]
+    fn test_dot_pattern_splitting() {
+        let input = create_string_chunked("input", vec![Some("a\rb\rc\nd\te")]);
+        
+        let result = flarion_split_helper(&input, ".", -1).unwrap().into_series();
+        
+        assert_eq!(result.len(), 1);
+        assert_eq!(
+            result.get(0).unwrap(),
+            AnyValue::List(Series::new(PlSmallStr::EMPTY, &["", "\r", "", "\r", "", "\n", "", "", ""]))
         );
     }
 }

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -200,7 +200,7 @@ mod tests {
             result.get(0).unwrap(),
             AnyValue::List(Series::new(
                 PlSmallStr::EMPTY,
-                &["", "\r", "", "\r", "", "\n", "", "", ""]
+                &["", "\r", "\r", "\n", "", "", ""]
             ))
         );
     }

--- a/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_split.rs
@@ -51,7 +51,7 @@ pub fn flarion_split_helper(
             pattern
         };
 
-        let re = RegexBuilder::new(&pattern)
+        let re = RegexBuilder::new(pattern)
             .size_limit(30 * 1024 * 1024)
             .build()?;
 

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -455,13 +455,15 @@ pub trait StringNameSpaceImpl: AsString {
     }
 
     fn is_direct_space(c: char) -> bool {
-        c == ' '  // Only matches U+0020 to be exactly like Spark's behavior
+        c == ' ' // Only matches U+0020 to be exactly like Spark's behavior
     }
 
     fn strip_chars(&self, pat: &Series) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
         if pat.dtype() == &DataType::Null {
-            Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_matches(Self::is_direct_space))))
+            Ok(unary_elementwise(ca, |opt_s| {
+                opt_s.map(|s| s.trim_matches(Self::is_direct_space))
+            }))
         } else {
             Ok(strip_chars(ca, pat.str()?))
         }
@@ -470,7 +472,9 @@ pub trait StringNameSpaceImpl: AsString {
     fn strip_chars_start(&self, pat: &Series) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
         if pat.dtype() == &DataType::Null {
-            return Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_start_matches(Self::is_direct_space))));
+            return Ok(unary_elementwise(ca, |opt_s| {
+                opt_s.map(|s| s.trim_start_matches(Self::is_direct_space))
+            }));
         } else {
             Ok(strip_chars_start(ca, pat.str()?))
         }
@@ -479,7 +483,9 @@ pub trait StringNameSpaceImpl: AsString {
     fn strip_chars_end(&self, pat: &Series) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
         if pat.dtype() == &DataType::Null {
-            return Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_end_matches(Self::is_direct_space))));
+            return Ok(unary_elementwise(ca, |opt_s| {
+                opt_s.map(|s| s.trim_end_matches(Self::is_direct_space))
+            }));
         } else {
             Ok(strip_chars_end(ca, pat.str()?))
         }

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -454,10 +454,14 @@ pub trait StringNameSpaceImpl: AsString {
         Ok(builder.finish())
     }
 
+    fn is_direct_space(c: char) -> bool {
+        c == ' '  // Only matches U+0020 to be exactly like Spark's behavior
+    }
+
     fn strip_chars(&self, pat: &Series) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
         if pat.dtype() == &DataType::Null {
-            Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim())))
+            Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_matches(Self::is_direct_space))))
         } else {
             Ok(strip_chars(ca, pat.str()?))
         }
@@ -466,7 +470,7 @@ pub trait StringNameSpaceImpl: AsString {
     fn strip_chars_start(&self, pat: &Series) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
         if pat.dtype() == &DataType::Null {
-            return Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_start())));
+            return Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_start_matches(Self::is_direct_space))));
         } else {
             Ok(strip_chars_start(ca, pat.str()?))
         }
@@ -475,7 +479,7 @@ pub trait StringNameSpaceImpl: AsString {
     fn strip_chars_end(&self, pat: &Series) -> PolarsResult<StringChunked> {
         let ca = self.as_string();
         if pat.dtype() == &DataType::Null {
-            return Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_end())));
+            return Ok(unary_elementwise(ca, |opt_s| opt_s.map(|s| s.trim_end_matches(Self::is_direct_space))));
         } else {
             Ok(strip_chars_end(ca, pat.str()?))
         }


### PR DESCRIPTION
\r and \n are special in Spark so they're not split like other chars (even \t).