### PR TITLE
fix(rust): Move substring and instr implementations into polars

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/flarion_funcs.rs
+++ b/crates/polars-core/src/chunked_array/ops/flarion_funcs.rs
@@ -1,0 +1,68 @@
+pub fn flarion_get_char_position(haystack: &str, needle: &str) -> i32 {
+    if needle.is_empty() {
+        return 1;
+    }
+
+    match haystack.find(needle) {
+        Some(byte_idx) => {
+            // Always add 1 since SQL uses 1-based indexing
+            1 + haystack[..byte_idx].chars().count() as i32
+        },
+        None => 0,
+    }
+}
+
+// Core substring function that handles a single string
+pub fn flarion_substring(s: &str, from: i32, len: i32) -> String {
+    if s.is_empty() || len <= 0 {
+        return String::new();
+    }
+
+    if from >= 0 {
+        // This implementation is pretty clean but would not work as well with negative 'from' values due to all sorts of Spark quirks.
+        let from_as_usize = match from {
+            0 => 0,
+            i => i - 1,
+        } as usize;
+
+        let mut iter = s.char_indices();
+
+        let start_char = iter.nth(from_as_usize);
+        let end_char = iter.nth(len as usize - 1);
+
+        match start_char {
+            None => String::new(),
+            Some((start_idx, _)) => match end_char {
+                None => s[start_idx..].to_string(),
+                Some((end_idx, _)) => s[start_idx..end_idx].to_string(),
+            },
+        }
+    } else {
+        let mut start_char = 0;
+        let mut end_char = 0;
+        let mut found_start = false;
+
+        let distance_to_advance = from.unsigned_abs() as usize;
+        let end_idx = std::cmp::max(0, distance_to_advance as i32 - len) as usize; // We know len is positive
+
+        for (idx, (byte_pos, ch)) in s.char_indices().rev().enumerate() {
+            // We will always reach this code because end_idx is smaller than distance_to_advance, and idx == distance_to_advance breaks the flow.
+            if idx == end_idx {
+                // The "+ ch.len_utf8()" operation is because we need to see where the char ends.
+                end_char = byte_pos + ch.len_utf8();
+            }
+
+            if idx == distance_to_advance {
+                // The "+ ch.len_utf8()" operation is because we need to see where the char ends.
+                start_char = byte_pos + ch.len_utf8();
+                found_start = true;
+                break;
+            }
+        }
+
+        match found_start {
+            true => s[start_char..end_char].to_string(),
+            false => s[..end_char].to_string(),
+        }
+    }
+}

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -5,6 +5,7 @@ use num_traits::ToBytes;
 #[cfg(feature = "serde-lazy")]
 use serde::{Deserialize, Serialize};
 
+use super::flarion_funcs::{flarion_get_char_position, flarion_substring};
 use super::DataType;
 use crate::datatypes::{AnyValue, PolarsNumericType};
 use crate::prelude::Array;
@@ -87,37 +88,16 @@ impl Hash for LambdaExpression {
     }
 }
 
-fn substring<'a>(s: AnyValue<'a>, from: AnyValue<'a>, len: AnyValue<'a>) -> AnyValue<'a> {
-    fn convert_indexes(from: i32, len: i32, s_len: usize) -> (usize, usize) {
-        let mut from = from as i64;
-        let len = len as i64; // this can be int32_max
-        let s_len = s_len as i64;
-        if from == 0 {
-            panic!("From can't be zero in 1 based indexation")
-        }
-        if from > 0 {
-            from -= 1;
-        }
-        if from < 0 {
-            from += s_len;
-        }
-        let to = (from + len).min(s_len);
-        (from.max(0) as usize, to.max(0) as usize)
-    }
-    unsafe {
-        match (s, from, len) {
-            (AnyValue::String(s), AnyValue::Int32(from), AnyValue::Int32(len)) => {
-                let (from, to) = convert_indexes(from, len, s.len());
-                let result = &s[from.max(0)..to.max(0)];
-                AnyValue::String(result)
-            },
-            (AnyValue::Binary(bin), AnyValue::Int32(from), AnyValue::Int32(len)) => {
-                let (from, to) = convert_indexes(from, len, bin.len());
-                let result = &bin[from.max(0)..to.max(0)];
-                AnyValue::Binary(result)
-            },
-            _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
-        }
+pub fn flarion_substring_anyvalue<'a>(
+    s: AnyValue<'a>,
+    from: AnyValue<'a>,
+    len: AnyValue<'a>,
+) -> AnyValue<'a> {
+    match (s, from, len) {
+        (AnyValue::String(s), AnyValue::Int32(from), AnyValue::Int32(len)) => {
+            AnyValue::StringOwned(flarion_substring(s, from, len).into())
+        },
+        _ => AnyValue::Null,
     }
 }
 
@@ -266,7 +246,7 @@ impl LambdaExpression {
                 let s = s.eval_array(args);
                 let from = from.eval_array(args).cast(&DataType::Int32);
                 let len = len.eval_array(args).cast(&DataType::Int32);
-                substring(s, from, len)
+                flarion_substring_anyvalue(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
                 let s = s.eval_array(args);
@@ -274,7 +254,7 @@ impl LambdaExpression {
                 unsafe {
                     match (s, pat) {
                         (AnyValue::String(s), AnyValue::String(pat)) => {
-                            AnyValue::Int32(s.find(pat).map(|x| x + 1).unwrap_or(0) as i32)
+                            AnyValue::Int32(flarion_get_char_position(s, pat))
                         },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }
@@ -348,7 +328,7 @@ impl LambdaExpression {
                 let s = s.eval_numeric::<T>(args);
                 let from = from.eval_numeric::<T>(args).cast(&DataType::Int32);
                 let len = len.eval_numeric::<T>(args).cast(&DataType::Int32);
-                substring(s, from, len)
+                flarion_substring_anyvalue(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
                 let s = s.eval_numeric::<T>(args);
@@ -356,7 +336,7 @@ impl LambdaExpression {
                 unsafe {
                     match (s, pat) {
                         (AnyValue::String(s), AnyValue::String(pat)) => {
-                            AnyValue::Int32(s.find(pat).map(|x| x + 1).unwrap_or(0) as i32)
+                            AnyValue::Int32(flarion_get_char_position(s, pat))
                         },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }
@@ -430,7 +410,7 @@ impl LambdaExpression {
                 let s = s.eval_bool(args);
                 let from = from.eval_bool(args).cast(&DataType::Int32);
                 let len = len.eval_bool(args).cast(&DataType::Int32);
-                substring(s, from, len)
+                flarion_substring_anyvalue(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
                 let s = s.eval_bool(args);
@@ -438,7 +418,7 @@ impl LambdaExpression {
                 unsafe {
                     match (s, pat) {
                         (AnyValue::String(s), AnyValue::String(pat)) => {
-                            AnyValue::Int32(s.find(pat).map(|x| x + 1).unwrap_or(0) as i32)
+                            AnyValue::Int32(flarion_get_char_position(s, pat))
                         },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }
@@ -515,7 +495,7 @@ impl LambdaExpression {
                 let s = s.eval_slice(args);
                 let from = from.eval_slice(args).cast(&DataType::Int32);
                 let len = len.eval_slice(args).cast(&DataType::Int32);
-                substring(s, from, len)
+                flarion_substring_anyvalue(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
                 let s = s.eval_slice(args);
@@ -523,7 +503,7 @@ impl LambdaExpression {
                 unsafe {
                     match (s, pat) {
                         (AnyValue::String(s), AnyValue::String(pat)) => {
-                            AnyValue::Int32(s.find(pat).map(|x| x + 1).unwrap_or(0) as i32)
+                            AnyValue::Int32(flarion_get_char_position(s, pat))
                         },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }
@@ -599,7 +579,7 @@ impl LambdaExpression {
                 let s = s.eval_any(args);
                 let from = from.eval_any(args).cast(&DataType::Int32);
                 let len = len.eval_any(args).cast(&DataType::Int32);
-                substring(s, from, len)
+                flarion_substring_anyvalue(s, from, len)
             },
             LambdaExpression::Instr(s, pat) => {
                 let s = s.eval_any(args);
@@ -607,7 +587,7 @@ impl LambdaExpression {
                 unsafe {
                     match (s, pat) {
                         (AnyValue::String(s), AnyValue::String(pat)) => {
-                            AnyValue::Int32(s.find(pat).map(|x| x + 1).unwrap_or(0) as i32)
+                            AnyValue::Int32(flarion_get_char_position(s, pat))
                         },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }

--- a/crates/polars-core/src/chunked_array/ops/mod.rs
+++ b/crates/polars-core/src/chunked_array/ops/mod.rs
@@ -19,6 +19,7 @@ mod explode_and_offsets;
 mod extend;
 pub mod fill_null;
 mod filter;
+pub mod flarion_funcs;
 mod flatten;
 pub mod float_sorted_arg_max;
 mod for_each;

--- a/crates/polars-ops/src/chunked_array/strings/flarion_instr.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_instr.rs
@@ -1,0 +1,49 @@
+use polars_core::prelude::{Int32Chunked, StringChunked};
+use polars_core::series::{IntoSeries, Series};
+use polars_error::{PolarsError, PolarsResult};
+
+pub fn flarion_instr_helper(
+    string_series: &StringChunked,
+    pattern: &Series,
+) -> PolarsResult<Series> {
+    let pattern_series = pattern.str()?;
+
+    let result = if pattern_series.len() == 1 {
+        let pattern = pattern_series.get(0).unwrap_or("");
+        string_series
+            .into_iter()
+            .map(|opt_str| opt_str.map(|s| get_char_position(s, pattern)))
+            .collect::<Int32Chunked>()
+            .into_series()
+    } else if string_series.len() == pattern_series.len() {
+        string_series
+            .into_iter()
+            .zip(pattern_series)
+            .map(|(opt_s, opt_p)| match (opt_s, opt_p) {
+                (Some(s), Some(p)) => Some(get_char_position(s, p)),
+                _ => None,
+            })
+            .collect::<Int32Chunked>()
+            .into_series()
+    } else {
+        return Err(PolarsError::ComputeError(
+            "Lengths of 'string' and 'pattern' series must be equal or pattern series must have length 1".into(),
+        ));
+    };
+
+    Ok(result)
+}
+
+fn get_char_position(haystack: &str, needle: &str) -> i32 {
+    if needle.is_empty() {
+        return 1;
+    }
+
+    match haystack.find(needle) {
+        Some(byte_idx) => {
+            // Always add 1 since SQL uses 1-based indexing
+            1 + haystack[..byte_idx].chars().count() as i32
+        },
+        None => 0,
+    }
+}

--- a/crates/polars-ops/src/chunked_array/strings/flarion_instr.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_instr.rs
@@ -1,3 +1,4 @@
+use polars_core::prelude::flarion_funcs::flarion_get_char_position;
 use polars_core::prelude::{Int32Chunked, StringChunked};
 use polars_core::series::{IntoSeries, Series};
 use polars_error::{PolarsError, PolarsResult};
@@ -12,7 +13,7 @@ pub fn flarion_instr_helper(
         let pattern = pattern_series.get(0).unwrap_or("");
         string_series
             .into_iter()
-            .map(|opt_str| opt_str.map(|s| get_char_position(s, pattern)))
+            .map(|opt_str| opt_str.map(|s| flarion_get_char_position(s, pattern)))
             .collect::<Int32Chunked>()
             .into_series()
     } else if string_series.len() == pattern_series.len() {
@@ -20,7 +21,7 @@ pub fn flarion_instr_helper(
             .into_iter()
             .zip(pattern_series)
             .map(|(opt_s, opt_p)| match (opt_s, opt_p) {
-                (Some(s), Some(p)) => Some(get_char_position(s, p)),
+                (Some(s), Some(p)) => Some(flarion_get_char_position(s, p)),
                 _ => None,
             })
             .collect::<Int32Chunked>()
@@ -32,18 +33,4 @@ pub fn flarion_instr_helper(
     };
 
     Ok(result)
-}
-
-fn get_char_position(haystack: &str, needle: &str) -> i32 {
-    if needle.is_empty() {
-        return 1;
-    }
-
-    match haystack.find(needle) {
-        Some(byte_idx) => {
-            // Always add 1 since SQL uses 1-based indexing
-            1 + haystack[..byte_idx].chars().count() as i32
-        },
-        None => 0,
-    }
 }

--- a/crates/polars-ops/src/chunked_array/strings/flarion_slice.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_slice.rs
@@ -1,0 +1,153 @@
+use polars_core::prelude::{DataType, StringChunked, StringChunkedBuilder};
+use polars_core::series::{IntoSeries, Series};
+use polars_error::PolarsResult;
+
+pub fn flarion_slice_helper(
+    strings: &StringChunked,
+    offset: &Series,
+    length: &Series,
+) -> PolarsResult<Series> {
+    let froms_iter = offset.i32()?;
+    let lens_iter = length.i32()?;
+
+    if froms_iter.is_empty() || lens_iter.is_empty() {
+        return Ok(Series::full_null(
+            "".into(),
+            strings.len(),
+            &DataType::String,
+        ));
+    }
+
+    // Helper function to handle substring with null length
+    let substring_with_null_length = |s: &str, from: i32| match from {
+        f if f <= 0 || f == 1 => Some(s.to_string()),
+        f if (f as usize) <= s.len() => Some(s[(f as usize - 1)..].to_string()),
+        _ => None,
+    };
+
+    let froms_length = froms_iter.len();
+    let lens_length = lens_iter.len();
+    let first_from = froms_iter.get(0);
+    let first_len = lens_iter.get(0);
+
+    // Fast path: if froms_iter is length 1 and it's null, return all nulls
+    if froms_length == 1 && first_from.is_none() {
+        return Ok(Series::full_null(
+            "".into(),
+            strings.len(),
+            &DataType::String,
+        ));
+    }
+
+    let result: StringChunked = match (froms_length, lens_length) {
+        // Commented out because it is already covered in previous check
+        // (0, _) | (_, 0) => None,
+        (1, _) => {
+            let mut builder = StringChunkedBuilder::new("".into(), strings.len());
+            for (s_opt, len_opt) in strings.into_iter().zip(lens_iter) {
+                let value = match (s_opt, first_from, len_opt) {
+                    (Some(s), Some(from), Some(len)) => Some(substring_core(s, from, len)),
+                    (Some(s), Some(from), None) => substring_with_null_length(s, from),
+                    _ => None,
+                };
+                builder.append_option(value);
+            }
+            builder.finish()
+        },
+        (_, 1) => {
+            let mut builder = StringChunkedBuilder::new("".into(), strings.len());
+            for (s_opt, from_opt) in strings.into_iter().zip(froms_iter) {
+                let value = match (s_opt, from_opt, first_len) {
+                    (Some(s), Some(from), Some(len)) => Some(substring_core(s, from, len)),
+                    (Some(s), Some(from), None) => substring_with_null_length(s, from),
+                    _ => None,
+                };
+                builder.append_option(value);
+            }
+            builder.finish()
+        },
+        _ => {
+            let mut builder = StringChunkedBuilder::new("".into(), strings.len());
+            for (s_opt, (from_opt, len_opt)) in strings
+                .into_iter()
+                .zip(froms_iter.into_iter().zip(lens_iter))
+            {
+                let value = match (s_opt, from_opt, len_opt) {
+                    (Some(s), Some(from), Some(len)) => Some(substring_core(s, from, len)),
+                    (Some(s), Some(from), None) => substring_with_null_length(s, from),
+                    _ => None,
+                };
+                builder.append_option(value);
+            }
+            builder.finish()
+        },
+    };
+
+    Ok(result.into_series())
+}
+
+// Core substring function that handles a single string
+fn substring_core(s: &str, from: i32, len: i32) -> String {
+    if s.is_empty() || len <= 0 {
+        return String::new();
+    }
+
+    if from >= 0 {
+        // This implementation is pretty clean but would not work as well with negative 'from' values due to all sorts of Spark quirks.
+        let from_as_usize = match from {
+            0 => 0,
+            i => i - 1,
+        } as usize;
+
+        let mut iter = s.char_indices();
+
+        let start_char = iter.nth(from_as_usize);
+        let end_char = iter.nth(len as usize - 1);
+
+        match start_char {
+            None => String::new(),
+            Some((start_idx, _)) => match end_char {
+                None => s[start_idx..].to_string(),
+                Some((end_idx, _)) => s[start_idx..end_idx].to_string(),
+            },
+        }
+    } else {
+        let mut start_char = 0;
+        let mut end_char = 0;
+        let mut found_start = false;
+
+        let distance_to_advance = from.unsigned_abs() as usize;
+        let end_idx = std::cmp::max(0, distance_to_advance as i32 - len) as usize; // We know len is positive
+
+        for (idx, (byte_pos, ch)) in s.char_indices().rev().enumerate() {
+            // We will always reach this code because end_idx is smaller than distance_to_advance, and idx == distance_to_advance breaks the flow.
+            if idx == end_idx {
+                // The "+ ch.len_utf8()" operation is because we need to see where the char ends.
+                end_char = byte_pos + ch.len_utf8();
+            }
+
+            if idx == distance_to_advance {
+                // The "+ ch.len_utf8()" operation is because we need to see where the char ends.
+                start_char = byte_pos + ch.len_utf8();
+                found_start = true;
+                break;
+            }
+        }
+
+        match found_start {
+            true => s[start_char..end_char].to_string(),
+            false => s[..end_char].to_string(),
+        }
+    }
+}
+
+/*
+// Function that handles Series operations and calls substring_core
+fn substring(params: &mut [Series]) -> PolarsResult<Option<Series>> {
+    if params.len() != 3 {
+        return Ok(None);
+    }
+
+
+}
+    */

--- a/crates/polars-ops/src/chunked_array/strings/flarion_slice.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_slice.rs
@@ -8,10 +8,10 @@ pub fn flarion_slice_helper(
     offset: &Series,
     length: &Series,
 ) -> PolarsResult<Series> {
-    let froms_iter = offset.i32()?;
+    let from_iter = offset.i32()?;
     let lens_iter = length.i32()?;
 
-    if froms_iter.is_empty() || lens_iter.is_empty() {
+    if from_iter.is_empty() || lens_iter.is_empty() {
         return Ok(Series::full_null(
             "".into(),
             strings.len(),
@@ -26,12 +26,12 @@ pub fn flarion_slice_helper(
         _ => None,
     };
 
-    let froms_length = froms_iter.len();
+    let froms_length = from_iter.len();
     let lens_length = lens_iter.len();
-    let first_from = froms_iter.get(0);
+    let first_from = from_iter.get(0);
     let first_len = lens_iter.get(0);
 
-    // Fast path: if froms_iter is length 1 and it's null, return all nulls
+    // Fast path: if from_iter is length 1 and it's null, return all nulls
     if froms_length == 1 && first_from.is_none() {
         return Ok(Series::full_null(
             "".into(),
@@ -57,7 +57,7 @@ pub fn flarion_slice_helper(
         },
         (_, 1) => {
             let mut builder = StringChunkedBuilder::new("".into(), strings.len());
-            for (s_opt, from_opt) in strings.into_iter().zip(froms_iter) {
+            for (s_opt, from_opt) in strings.into_iter().zip(from_iter) {
                 let value = match (s_opt, from_opt, first_len) {
                     (Some(s), Some(from), Some(len)) => Some(flarion_substring(s, from, len)),
                     (Some(s), Some(from), None) => substring_with_null_length(s, from),
@@ -71,7 +71,7 @@ pub fn flarion_slice_helper(
             let mut builder = StringChunkedBuilder::new("".into(), strings.len());
             for (s_opt, (from_opt, len_opt)) in strings
                 .into_iter()
-                .zip(froms_iter.into_iter().zip(lens_iter))
+                .zip(from_iter.into_iter().zip(lens_iter))
             {
                 let value = match (s_opt, from_opt, len_opt) {
                     (Some(s), Some(from), Some(len)) => Some(flarion_substring(s, from, len)),

--- a/crates/polars-ops/src/chunked_array/strings/flarion_slice.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_slice.rs
@@ -26,13 +26,13 @@ pub fn flarion_slice_helper(
         _ => None,
     };
 
-    let froms_length = from_iter.len();
+    let from_length = from_iter.len();
     let lens_length = lens_iter.len();
     let first_from = from_iter.get(0);
     let first_len = lens_iter.get(0);
 
     // Fast path: if from_iter is length 1 and it's null, return all nulls
-    if froms_length == 1 && first_from.is_none() {
+    if from_length == 1 && first_from.is_none() {
         return Ok(Series::full_null(
             "".into(),
             strings.len(),
@@ -40,7 +40,7 @@ pub fn flarion_slice_helper(
         ));
     }
 
-    let result: StringChunked = match (froms_length, lens_length) {
+    let result: StringChunked = match (from_length, lens_length) {
         // Commented out because it is already covered in previous check
         // (0, _) | (_, 0) => None,
         (1, _) => {

--- a/crates/polars-ops/src/chunked_array/strings/flarion_slice.rs
+++ b/crates/polars-ops/src/chunked_array/strings/flarion_slice.rs
@@ -1,3 +1,4 @@
+use polars_core::chunked_array::ops::flarion_funcs::flarion_substring;
 use polars_core::prelude::{DataType, StringChunked, StringChunkedBuilder};
 use polars_core::series::{IntoSeries, Series};
 use polars_error::PolarsResult;
@@ -46,7 +47,7 @@ pub fn flarion_slice_helper(
             let mut builder = StringChunkedBuilder::new("".into(), strings.len());
             for (s_opt, len_opt) in strings.into_iter().zip(lens_iter) {
                 let value = match (s_opt, first_from, len_opt) {
-                    (Some(s), Some(from), Some(len)) => Some(substring_core(s, from, len)),
+                    (Some(s), Some(from), Some(len)) => Some(flarion_substring(s, from, len)),
                     (Some(s), Some(from), None) => substring_with_null_length(s, from),
                     _ => None,
                 };
@@ -58,7 +59,7 @@ pub fn flarion_slice_helper(
             let mut builder = StringChunkedBuilder::new("".into(), strings.len());
             for (s_opt, from_opt) in strings.into_iter().zip(froms_iter) {
                 let value = match (s_opt, from_opt, first_len) {
-                    (Some(s), Some(from), Some(len)) => Some(substring_core(s, from, len)),
+                    (Some(s), Some(from), Some(len)) => Some(flarion_substring(s, from, len)),
                     (Some(s), Some(from), None) => substring_with_null_length(s, from),
                     _ => None,
                 };
@@ -73,7 +74,7 @@ pub fn flarion_slice_helper(
                 .zip(froms_iter.into_iter().zip(lens_iter))
             {
                 let value = match (s_opt, from_opt, len_opt) {
-                    (Some(s), Some(from), Some(len)) => Some(substring_core(s, from, len)),
+                    (Some(s), Some(from), Some(len)) => Some(flarion_substring(s, from, len)),
                     (Some(s), Some(from), None) => substring_with_null_length(s, from),
                     _ => None,
                 };
@@ -85,69 +86,3 @@ pub fn flarion_slice_helper(
 
     Ok(result.into_series())
 }
-
-// Core substring function that handles a single string
-fn substring_core(s: &str, from: i32, len: i32) -> String {
-    if s.is_empty() || len <= 0 {
-        return String::new();
-    }
-
-    if from >= 0 {
-        // This implementation is pretty clean but would not work as well with negative 'from' values due to all sorts of Spark quirks.
-        let from_as_usize = match from {
-            0 => 0,
-            i => i - 1,
-        } as usize;
-
-        let mut iter = s.char_indices();
-
-        let start_char = iter.nth(from_as_usize);
-        let end_char = iter.nth(len as usize - 1);
-
-        match start_char {
-            None => String::new(),
-            Some((start_idx, _)) => match end_char {
-                None => s[start_idx..].to_string(),
-                Some((end_idx, _)) => s[start_idx..end_idx].to_string(),
-            },
-        }
-    } else {
-        let mut start_char = 0;
-        let mut end_char = 0;
-        let mut found_start = false;
-
-        let distance_to_advance = from.unsigned_abs() as usize;
-        let end_idx = std::cmp::max(0, distance_to_advance as i32 - len) as usize; // We know len is positive
-
-        for (idx, (byte_pos, ch)) in s.char_indices().rev().enumerate() {
-            // We will always reach this code because end_idx is smaller than distance_to_advance, and idx == distance_to_advance breaks the flow.
-            if idx == end_idx {
-                // The "+ ch.len_utf8()" operation is because we need to see where the char ends.
-                end_char = byte_pos + ch.len_utf8();
-            }
-
-            if idx == distance_to_advance {
-                // The "+ ch.len_utf8()" operation is because we need to see where the char ends.
-                start_char = byte_pos + ch.len_utf8();
-                found_start = true;
-                break;
-            }
-        }
-
-        match found_start {
-            true => s[start_char..end_char].to_string(),
-            false => s[..end_char].to_string(),
-        }
-    }
-}
-
-/*
-// Function that handles Series operations and calls substring_core
-fn substring(params: &mut [Series]) -> PolarsResult<Option<Series>> {
-    if params.len() != 3 {
-        return Ok(None);
-    }
-
-
-}
-    */

--- a/crates/polars-ops/src/chunked_array/strings/mod.rs
+++ b/crates/polars-ops/src/chunked_array/strings/mod.rs
@@ -6,7 +6,7 @@ mod concat;
 mod extract;
 #[cfg(feature = "find_many")]
 mod find_many;
-#[cfg(all(feature = "strings"))]
+#[cfg(feature = "strings")]
 mod flarion_instr;
 #[cfg(all(feature = "strings"))]
 mod flarion_slice;
@@ -34,9 +34,9 @@ mod unicode_internals;
 pub use concat::*;
 #[cfg(feature = "find_many")]
 pub use find_many::*;
-#[cfg(all(feature = "strings"))]
+#[cfg(feature = "strings")]
 pub use flarion_instr::*;
-#[cfg(all(feature = "strings"))]
+#[cfg(feature = "strings")]
 pub use flarion_slice::*;
 #[cfg(all(feature = "strings", feature = "dtype-struct"))]
 pub use flarion_split::*;

--- a/crates/polars-ops/src/chunked_array/strings/mod.rs
+++ b/crates/polars-ops/src/chunked_array/strings/mod.rs
@@ -8,7 +8,7 @@ mod extract;
 mod find_many;
 #[cfg(feature = "strings")]
 mod flarion_instr;
-#[cfg(all(feature = "strings"))]
+#[cfg(feature = "strings")]
 mod flarion_slice;
 #[cfg(all(feature = "strings", feature = "dtype-struct"))]
 mod flarion_split;

--- a/crates/polars-ops/src/chunked_array/strings/mod.rs
+++ b/crates/polars-ops/src/chunked_array/strings/mod.rs
@@ -6,6 +6,10 @@ mod concat;
 mod extract;
 #[cfg(feature = "find_many")]
 mod find_many;
+#[cfg(all(feature = "strings"))]
+mod flarion_instr;
+#[cfg(all(feature = "strings"))]
+mod flarion_slice;
 #[cfg(all(feature = "strings", feature = "dtype-struct"))]
 mod flarion_split;
 #[cfg(feature = "extract_jsonpath")]
@@ -30,6 +34,10 @@ mod unicode_internals;
 pub use concat::*;
 #[cfg(feature = "find_many")]
 pub use find_many::*;
+#[cfg(all(feature = "strings"))]
+pub use flarion_instr::*;
+#[cfg(all(feature = "strings"))]
+pub use flarion_slice::*;
 #[cfg(all(feature = "strings", feature = "dtype-struct"))]
 pub use flarion_split::*;
 #[cfg(feature = "extract_jsonpath")]

--- a/crates/polars-ops/src/chunked_array/strings/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/strings/namespace.rs
@@ -514,11 +514,23 @@ pub trait StringNameSpaceImpl: AsString {
         split_helper(ca, by, str::split_inclusive)
     }
 
+    fn flarion_instr(&self, pattern: &Series) -> PolarsResult<Series> {
+        let ca = self.as_string();
+
+        flarion_instr_helper(ca, pattern)
+    }
+
     #[cfg(feature = "dtype-struct")]
     fn flarion_split(&self, pattern: &str, n: i32) -> PolarsResult<ListChunked> {
         let ca = self.as_string();
 
         flarion_split_helper(ca, pattern, n)
+    }
+
+    fn flarion_slice(&self, offset: &Series, length: &Series) -> PolarsResult<Series> {
+        let ca = self.as_string();
+
+        flarion_slice_helper(ca, offset, length)
     }
 
     /// Extract each successive non-overlapping regex match in an individual string as an array.

--- a/crates/polars-ops/src/chunked_array/strings/substring.rs
+++ b/crates/polars-ops/src/chunked_array/strings/substring.rs
@@ -154,14 +154,6 @@ fn update_view(mut view: View, start: usize, end: usize, val: &str) -> View {
     }
 }
 
-pub(super) fn flarion_substring(
-    ca: &StringChunked,
-    offset: &Series,
-    length: &Series,
-) -> StringChunked {
-    panic!("HELLO FLARION");
-}
-
 pub(super) fn substring(
     ca: &StringChunked,
     offset: &Int64Chunked,

--- a/crates/polars-ops/src/chunked_array/strings/substring.rs
+++ b/crates/polars-ops/src/chunked_array/strings/substring.rs
@@ -1,7 +1,6 @@
 use arrow::array::View;
 use polars_core::prelude::arity::{binary_elementwise, ternary_elementwise, unary_elementwise};
 use polars_core::prelude::{ChunkFullNull, Int64Chunked, StringChunked, UInt64Chunked};
-use polars_core::series::Series;
 use polars_error::{polars_ensure, PolarsResult};
 
 fn head_binary(opt_str_val: Option<&str>, opt_n: Option<i64>) -> Option<&str> {

--- a/crates/polars-ops/src/chunked_array/strings/substring.rs
+++ b/crates/polars-ops/src/chunked_array/strings/substring.rs
@@ -1,6 +1,7 @@
 use arrow::array::View;
 use polars_core::prelude::arity::{binary_elementwise, ternary_elementwise, unary_elementwise};
 use polars_core::prelude::{ChunkFullNull, Int64Chunked, StringChunked, UInt64Chunked};
+use polars_core::series::Series;
 use polars_error::{polars_ensure, PolarsResult};
 
 fn head_binary(opt_str_val: Option<&str>, opt_n: Option<i64>) -> Option<&str> {
@@ -151,6 +152,14 @@ fn update_view(mut view: View, start: usize, end: usize, val: &str) -> View {
         view.prefix = u32::from_le_bytes(subval[0..4].try_into().unwrap());
         view
     }
+}
+
+pub(super) fn flarion_substring(
+    ca: &StringChunked,
+    offset: &Series,
+    length: &Series,
+) -> StringChunked {
+    panic!("HELLO FLARION");
 }
 
 pub(super) fn substring(

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -210,7 +210,7 @@ impl StringFunction {
             #[cfg(feature = "find_many")]
             ExtractMany { .. } => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
 
-            FlarionInstr { .. } => mapper.with_same_dtype(),
+            FlarionInstr { .. } => mapper.with_dtype(DataType::Int32),
             #[cfg(all(feature = "regex", feature = "dtype-struct"))]
             FlarionSplit { .. } => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
             FlarionSlice { .. } => mapper.with_same_dtype(),

--- a/crates/polars-plan/src/dsl/function_expr/strings.rs
+++ b/crates/polars-plan/src/dsl/function_expr/strings.rs
@@ -135,11 +135,13 @@ pub enum StringFunction {
     },
 
     // Flarion functions
+    FlarionInstr,
     #[cfg(all(feature = "regex", feature = "dtype-struct"))]
     FlarionSplit {
         pattern: PlSmallStr,
         n: i32,
     },
+    FlarionSlice,
 }
 
 impl StringFunction {
@@ -208,8 +210,10 @@ impl StringFunction {
             #[cfg(feature = "find_many")]
             ExtractMany { .. } => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
 
+            FlarionInstr { .. } => mapper.with_same_dtype(),
             #[cfg(all(feature = "regex", feature = "dtype-struct"))]
             FlarionSplit { .. } => mapper.with_dtype(DataType::List(Box::new(DataType::String))),
+            FlarionSlice { .. } => mapper.with_same_dtype(),
         }
     }
 }
@@ -300,6 +304,8 @@ impl Display for StringFunction {
             ExtractMany { .. } => "extract_many",
 
             // Flarion functions
+            FlarionInstr { .. } => "flarion_instr",
+            FlarionSlice { .. } => "flarion_slice",
             #[cfg(all(feature = "regex", feature = "dtype-struct"))]
             FlarionSplit { .. } => "flarion_split",
         };
@@ -420,6 +426,8 @@ impl From<StringFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             },
 
             // Flarion functions
+            FlarionInstr {} => map_as_slice!(strings::flarion_instr),
+            FlarionSlice {} => map_as_slice!(strings::flarion_slice),
             #[cfg(all(feature = "regex", feature = "dtype-struct"))]
             FlarionSplit { pattern, n } => {
                 map_as_slice!(strings::flarion_split, pattern.as_str(), n)
@@ -680,6 +688,27 @@ pub(super) fn split(s: &[Series], inclusive: bool) -> PolarsResult<Series> {
     } else {
         Ok(ca.split(by).into_series())
     }
+}
+
+pub(super) fn flarion_instr(s: &[Series]) -> PolarsResult<Series> {
+    polars_ensure!(
+        _ensure_lengths(s),
+        ComputeError: "all series in `str_slice` should have equal or unit length",
+    );
+    let ca = s[0].str()?;
+    let pattern: &Series = &s[1];
+    Ok(ca.flarion_instr(pattern)?.into_series())
+}
+
+pub(super) fn flarion_slice(s: &[Series]) -> PolarsResult<Series> {
+    polars_ensure!(
+        _ensure_lengths(s),
+        ComputeError: "all series in `str_slice` should have equal or unit length",
+    );
+    let ca = s[0].str()?;
+    let offset: &Series = &s[1];
+    let length = &s[2];
+    Ok(ca.flarion_slice(offset, length)?.into_series())
 }
 
 #[cfg(all(feature = "regex", feature = "dtype-struct"))]

--- a/crates/polars-plan/src/dsl/string.rs
+++ b/crates/polars-plan/src/dsl/string.rs
@@ -608,6 +608,15 @@ impl StringNameSpace {
         )
     }
 
+    pub fn flarion_instr(self, pattern: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::StringExpr(StringFunction::FlarionInstr),
+            &[pattern],
+            false,
+            None,
+        )
+    }
+
     /// Split the string by a substring regex. The resulting dtype is `List<String>`.
     #[cfg(all(feature = "regex", feature = "dtype-struct"))]
     pub fn flarion_split(self, pattern: &str, n: i32) -> Expr {
@@ -617,6 +626,15 @@ impl StringNameSpace {
                 n,
             }
             .into(),
+        )
+    }
+
+    pub fn flarion_slice(self, offset: Expr, length: Expr) -> Expr {
+        self.0.map_many_private(
+            FunctionExpr::StringExpr(StringFunction::FlarionSlice),
+            &[offset, length],
+            false,
+            None,
         )
     }
 }


### PR DESCRIPTION
This makes substr and instr correctly handle unicode, which is not the case with the previous implementation. Also exports the functions so that accelerator can use them directly. Verified in tests in accelerator PR https://github.com/flarioncode/accelerator/pull/221.