### PR TITLE
fix(rust): Fix unicode length & dtype issues with array of null in lambda

### DIFF
--- a/crates/polars-core/src/chunked_array/from_iterator.rs
+++ b/crates/polars-core/src/chunked_array/from_iterator.rs
@@ -231,7 +231,7 @@ impl FromIterator<Option<Series>> for ListChunked {
 
                             for opt_s in it {
                                 if let Some(s) = opt_s {
-                                    if s.len() != 0 {
+                                    if !s.is_empty() {
                                         builder.append_series(&s).unwrap();
                                     } else {
                                         let new_s =

--- a/crates/polars-core/src/chunked_array/from_iterator.rs
+++ b/crates/polars-core/src/chunked_array/from_iterator.rs
@@ -233,10 +233,11 @@ impl FromIterator<Option<Series>> for ListChunked {
                                 if let Some(s) = opt_s {
                                     if s.len() != 0 {
                                         builder.append_series(&s).unwrap();
-                                    } else { 
-                                        let new_s = Series::new_empty(PlSmallStr::EMPTY, first_s.dtype());
-                                        builder.append_series(&new_s).unwrap(); 
-                                    } 
+                                    } else {
+                                        let new_s =
+                                            Series::new_empty(PlSmallStr::EMPTY, first_s.dtype());
+                                        builder.append_series(&new_s).unwrap();
+                                    }
                                 } else {
                                     builder.append_null();
                                 }

--- a/crates/polars-core/src/chunked_array/from_iterator.rs
+++ b/crates/polars-core/src/chunked_array/from_iterator.rs
@@ -230,7 +230,16 @@ impl FromIterator<Option<Series>> for ListChunked {
                             builder.append_series(first_s).unwrap();
 
                             for opt_s in it {
-                                builder.append_opt_series(opt_s.as_ref()).unwrap();
+                                if let Some(s) = opt_s {
+                                    if s.len() != 0 {
+                                        builder.append_series(&s).unwrap();
+                                    } else { 
+                                        let new_s = Series::new_empty(PlSmallStr::EMPTY, first_s.dtype());
+                                        builder.append_series(&new_s).unwrap(); 
+                                    } 
+                                } else {
+                                    builder.append_null();
+                                }
                             }
                             builder.finish()
                         },

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -103,44 +103,6 @@ pub fn flarion_substring_anyvalue<'a>(
 
 impl LambdaExpression {
     #[inline]
-    fn has_var(&self) -> bool {
-        let mut stack = vec![self];
-        while let Some(current) = stack.pop() {
-            match current {
-                LambdaExpression::Variable(_) => return true,
-                LambdaExpression::IsNull(inner) => stack.push(inner),
-                LambdaExpression::GreaterThan(left, right) |
-                LambdaExpression::LessThan(left, right) |
-                LambdaExpression::Add(left, right) |
-                LambdaExpression::Instr(left, right) => {
-                    stack.push(left);
-                    stack.push(right);
-                },
-                LambdaExpression::IfThenElse(cond, then_expr, else_expr) => {
-                    stack.push(cond);
-                    stack.push(then_expr);
-                    stack.push(else_expr);
-                },
-                LambdaExpression::Substring(s, from, len) => {
-                    stack.push(s);
-                    stack.push(from);
-                    stack.push(len);
-                },
-                LambdaExpression::CaseWhen(cases, otherwise) => {
-                    stack.push(otherwise);
-                    for (cond, value) in cases {
-                        stack.push(cond);
-                        stack.push(value);
-                    }
-                },
-                LambdaExpression::Length(expr) => stack.push(expr),
-                _ => (),
-            }
-        }
-        false
-    }
-
-    #[inline]
     pub(crate) fn eval_array<'a>(&'a self, args: &'a [&'a dyn Array]) -> AnyValue<'a> {
         match self {
             LambdaExpression::Null => AnyValue::Null,

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -103,6 +103,44 @@ pub fn flarion_substring_anyvalue<'a>(
 
 impl LambdaExpression {
     #[inline]
+    fn has_var(&self) -> bool {
+        let mut stack = vec![self];
+        while let Some(current) = stack.pop() {
+            match current {
+                LambdaExpression::Variable(_) => return true,
+                LambdaExpression::IsNull(inner) => stack.push(inner),
+                LambdaExpression::GreaterThan(left, right) |
+                LambdaExpression::LessThan(left, right) |
+                LambdaExpression::Add(left, right) |
+                LambdaExpression::Instr(left, right) => {
+                    stack.push(left);
+                    stack.push(right);
+                },
+                LambdaExpression::IfThenElse(cond, then_expr, else_expr) => {
+                    stack.push(cond);
+                    stack.push(then_expr);
+                    stack.push(else_expr);
+                },
+                LambdaExpression::Substring(s, from, len) => {
+                    stack.push(s);
+                    stack.push(from);
+                    stack.push(len);
+                },
+                LambdaExpression::CaseWhen(cases, otherwise) => {
+                    stack.push(otherwise);
+                    for (cond, value) in cases {
+                        stack.push(cond);
+                        stack.push(value);
+                    }
+                },
+                LambdaExpression::Length(expr) => stack.push(expr),
+                _ => (),
+            }
+        }
+        false
+    }
+
+    #[inline]
     pub(crate) fn eval_array<'a>(&'a self, args: &'a [&'a dyn Array]) -> AnyValue<'a> {
         match self {
             LambdaExpression::Null => AnyValue::Null,
@@ -628,13 +666,12 @@ impl LambdaExpression {
             LambdaExpression::Length(_) => Some(DataType::Int32),
             LambdaExpression::CaseWhen(cases, _) => cases
                 .iter()
-                .find_map(|pair| {
-                    if let Some(dtype) = pair.1.return_type() {
-                        dtype.is_null().then_some(dtype).map(Some)
-                    } else {
-                        Some(None)
-                    }
+                .map(|pair| match pair.1.return_type() {
+                    None => None,
+                    Some(dtype) if dtype.is_null() => None,
+                    Some(dtype) => Some(dtype),
                 })
+                .next()
                 .unwrap_or(Some(DataType::Null)),
             LambdaExpression::Substring(s, _, _) => s.return_type(), // substring is used for string and byte arrays
             LambdaExpression::Instr(_, _) => Some(DataType::Int32),

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -558,7 +558,7 @@ impl LambdaExpression {
             LambdaExpression::Length(expr) => match expr.eval_any(args) {
                 AnyValue::Null => AnyValue::Null,
                 AnyValue::Binary(bytes) => AnyValue::Int32(bytes.len() as i32),
-                AnyValue::String(s) => AnyValue::Int32(s.len() as i32),
+                AnyValue::String(s) => AnyValue::Int32(s.chars().count() as i32),
                 AnyValue::List(arr) => AnyValue::Int32(arr.len() as i32),
                 _ => AnyValue::Int32(1),
             },

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -1,15 +1,16 @@
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 
-use num_traits::ToBytes;
-#[cfg(feature = "serde-lazy")]
-use serde::{Deserialize, Serialize};
-
 use super::flarion_funcs::{flarion_get_char_position, flarion_substring};
 use super::DataType;
 use crate::datatypes::{AnyValue, PolarsNumericType};
 use crate::prelude::Array;
 use crate::series::Series;
+use crate::utils::dtypes_to_supertype;
+use num_traits::ToBytes;
+use polars_error::{PolarsError, PolarsResult};
+#[cfg(feature = "serde-lazy")]
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
@@ -153,7 +154,7 @@ impl LambdaExpression {
                         }
                     },
                     (left, AnyValue::List(right_series)) => {
-                        // Left is scalar, right is array
+                        // Left is scalar, right is an array
                         if right_series.len() > 0 {
                             let right_first = right_series.get(0)
                                 .expect("could not get first value from array in scalar-right-array comparison");
@@ -199,7 +200,7 @@ impl LambdaExpression {
                         }
                     },
                     (left, AnyValue::List(right_series)) => {
-                        // Left is scalar, right is array
+                        // Left is scalar, right is an array
                         if right_series.len() > 0 {
                             let right_first = right_series.get(0)
                                 .expect("could not get first value from array in scalar-right-array comparison");
@@ -609,36 +610,41 @@ impl LambdaExpression {
     }
 
     // None encode that type same as input value
-    pub fn return_type(&self) -> Option<DataType> {
-        match self {
-            LambdaExpression::Null => Some(DataType::Null),
-            LambdaExpression::Boolean(_) => Some(DataType::Boolean),
-            LambdaExpression::Int8(_) => Some(DataType::Int8),
-            LambdaExpression::Int16(_) => Some(DataType::Int16),
-            LambdaExpression::Int32(_) => Some(DataType::Int32),
-            LambdaExpression::Int64(_) => Some(DataType::Int64),
-            LambdaExpression::Float32(_) => Some(DataType::Float32),
-            LambdaExpression::Float64(_) => Some(DataType::Float64),
-            LambdaExpression::BinaryBlob(_) => Some(DataType::Binary),
-            LambdaExpression::StaticStr(_) => Some(DataType::String),
-            LambdaExpression::Variable(_) => None,
-            LambdaExpression::GreaterThan(_, _) => Some(DataType::Boolean),
-            LambdaExpression::LessThan(_, _) => Some(DataType::Boolean),
-            LambdaExpression::IfThenElse(_, then, _) => then.return_type(),
-            LambdaExpression::Length(_) => Some(DataType::Int32),
-            LambdaExpression::CaseWhen(cases, _) => cases
-                .iter()
-                .map(|pair| match pair.1.return_type() {
-                    None => None,
-                    Some(dtype) if dtype.is_null() => None,
-                    Some(dtype) => Some(dtype),
-                })
-                .next()
-                .unwrap_or(Some(DataType::Null)),
-            LambdaExpression::Substring(s, _, _) => s.return_type(), // substring is used for string and byte arrays
-            LambdaExpression::Instr(_, _) => Some(DataType::Int32),
-            LambdaExpression::Add(left, _) => left.return_type(),
-            LambdaExpression::IsNull(_) => Some(DataType::Boolean),
-        }
+    pub fn return_type(&self, input_type: &DataType) -> Result<DataType, PolarsError> { // dtypes_to_supertype
+        Ok(match self {
+            LambdaExpression::Null => DataType::Null,
+            LambdaExpression::Boolean(_) => DataType::Boolean,
+            LambdaExpression::Int8(_) => DataType::Int8,
+            LambdaExpression::Int16(_) => DataType::Int16,
+            LambdaExpression::Int32(_) => DataType::Int32,
+            LambdaExpression::Int64(_) => DataType::Int64,
+            LambdaExpression::Float32(_) => DataType::Float32,
+            LambdaExpression::Float64(_) => DataType::Float64,
+            LambdaExpression::BinaryBlob(_) => DataType::Binary,
+            LambdaExpression::StaticStr(_) => DataType::String,
+            LambdaExpression::Variable(_) => input_type.clone(),
+            LambdaExpression::GreaterThan(_, _) => DataType::Boolean,
+            LambdaExpression::LessThan(_, _) => DataType::Boolean,
+            LambdaExpression::IfThenElse(_, then, els) => {
+                dtypes_to_supertype([&then.return_type(input_type)?, &els.return_type(input_type)?])?
+            }
+            LambdaExpression::Length(_) => DataType::Int32,
+            LambdaExpression::CaseWhen(cases, otherwise) => {
+                let child_types = cases
+                    .iter()
+                    .map(|pair| &pair.1)
+                    .chain([otherwise.as_ref()])
+                    .map(|expr| {
+                        expr.return_type(input_type)
+                    }).collect::<PolarsResult<Vec<_>>>()?;
+                dtypes_to_supertype(&child_types)?
+            },
+            LambdaExpression::Substring(s, _, _) => s.return_type(input_type)?, // substring is used for string and byte arrays
+            LambdaExpression::Instr(_, _) => DataType::Int32,
+            LambdaExpression::Add(left, right) => {
+                dtypes_to_supertype([&left.return_type(input_type)?, &right.return_type(input_type)?])?
+            }
+            LambdaExpression::IsNull(_) => DataType::Boolean,
+        })
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -1,16 +1,17 @@
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 
+use num_traits::ToBytes;
+use polars_error::{PolarsError, PolarsResult};
+#[cfg(feature = "serde-lazy")]
+use serde::{Deserialize, Serialize};
+
 use super::flarion_funcs::{flarion_get_char_position, flarion_substring};
 use super::DataType;
 use crate::datatypes::{AnyValue, PolarsNumericType};
 use crate::prelude::Array;
 use crate::series::Series;
 use crate::utils::dtypes_to_supertype;
-use num_traits::ToBytes;
-use polars_error::{PolarsError, PolarsResult};
-#[cfg(feature = "serde-lazy")]
-use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
@@ -610,7 +611,8 @@ impl LambdaExpression {
     }
 
     // None encode that type same as input value
-    pub fn return_type(&self, input_type: &DataType) -> Result<DataType, PolarsError> { // dtypes_to_supertype
+    pub fn return_type(&self, input_type: &DataType) -> Result<DataType, PolarsError> {
+        // dtypes_to_supertype
         Ok(match self {
             LambdaExpression::Null => DataType::Null,
             LambdaExpression::Boolean(_) => DataType::Boolean,
@@ -625,25 +627,26 @@ impl LambdaExpression {
             LambdaExpression::Variable(_) => input_type.clone(),
             LambdaExpression::GreaterThan(_, _) => DataType::Boolean,
             LambdaExpression::LessThan(_, _) => DataType::Boolean,
-            LambdaExpression::IfThenElse(_, then, els) => {
-                dtypes_to_supertype([&then.return_type(input_type)?, &els.return_type(input_type)?])?
-            }
+            LambdaExpression::IfThenElse(_, then, els) => dtypes_to_supertype([
+                &then.return_type(input_type)?,
+                &els.return_type(input_type)?,
+            ])?,
             LambdaExpression::Length(_) => DataType::Int32,
             LambdaExpression::CaseWhen(cases, otherwise) => {
                 let child_types = cases
                     .iter()
                     .map(|pair| &pair.1)
                     .chain([otherwise.as_ref()])
-                    .map(|expr| {
-                        expr.return_type(input_type)
-                    }).collect::<PolarsResult<Vec<_>>>()?;
+                    .map(|expr| expr.return_type(input_type))
+                    .collect::<PolarsResult<Vec<_>>>()?;
                 dtypes_to_supertype(&child_types)?
             },
             LambdaExpression::Substring(s, _, _) => s.return_type(input_type)?, // substring is used for string and byte arrays
             LambdaExpression::Instr(_, _) => DataType::Int32,
-            LambdaExpression::Add(left, right) => {
-                dtypes_to_supertype([&left.return_type(input_type)?, &right.return_type(input_type)?])?
-            }
+            LambdaExpression::Add(left, right) => dtypes_to_supertype([
+                &left.return_type(input_type)?,
+                &right.return_type(input_type)?,
+            ])?,
             LambdaExpression::IsNull(_) => DataType::Boolean,
         })
     }

--- a/crates/polars-core/src/chunked_array/ops/transform.rs
+++ b/crates/polars-core/src/chunked_array/ops/transform.rs
@@ -1,3 +1,6 @@
+use arrow::array::Array;
+use polars_utils::pl_str::PlSmallStr;
+
 use super::{
     BinaryChunked, BooleanChunked, ChunkTransform, ChunkedArray, ListChunked, PolarsNumericType,
     SeriesTrait, StringChunked,
@@ -5,8 +8,6 @@ use super::{
 use crate::prelude::AnyValue;
 use crate::series::implementations::SeriesWrap;
 use crate::series::{IntoSeries, Series};
-use arrow::array::Array;
-use polars_utils::pl_str::PlSmallStr;
 
 impl<T: PolarsNumericType + 'static> ChunkTransform for ChunkedArray<T>
 where
@@ -42,7 +43,9 @@ impl ChunkTransform for StringChunked {
         let vec: Vec<AnyValue> = self
             .iter()
             .enumerate()
-            .map(|(i, value)| lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)]))
+            .map(|(i, value)| {
+                lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)])
+            })
             .collect();
 
         let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
@@ -115,7 +118,7 @@ impl ChunkTransform for BooleanChunked {
             .enumerate()
             .map(|(i, value)| lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)]))
             .collect();
-
+        
         let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
         raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
     }

--- a/crates/polars-core/src/chunked_array/ops/transform.rs
+++ b/crates/polars-core/src/chunked_array/ops/transform.rs
@@ -29,8 +29,7 @@ where
             })
             .collect();
 
-        let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
-        raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
+        Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &vec, &lambda.return_type().unwrap_or(self.dtype().clone()), true)
     }
 }
 
@@ -48,8 +47,7 @@ impl ChunkTransform for StringChunked {
             })
             .collect();
 
-        let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
-        raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
+        Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &vec, &lambda.return_type().unwrap_or(self.dtype().clone()), true)
     }
 }
 
@@ -68,8 +66,7 @@ impl ChunkTransform for BinaryChunked {
             .map(|(i, value)| lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)]))
             .collect();
 
-        let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
-        raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
+        Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &vec, &lambda.return_type().unwrap_or(self.dtype().clone()), true)
     }
 }
 
@@ -99,8 +96,7 @@ impl ChunkTransform for ListChunked {
             .map(|(i, value)| lambda.eval_any(&[array_to_any(value), AnyValue::Int32(i as i32)]))
             .collect();
 
-        let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
-        raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
+        Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &vec, &lambda.return_type().unwrap_or(self.dtype().clone()), true)
     }
 }
 
@@ -119,7 +115,6 @@ impl ChunkTransform for BooleanChunked {
             .map(|(i, value)| lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)]))
             .collect();
         
-        let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
-        raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
+        Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &vec, &lambda.return_type().unwrap_or(self.dtype().clone()), true)
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/transform.rs
+++ b/crates/polars-core/src/chunked_array/ops/transform.rs
@@ -1,5 +1,3 @@
-use arrow::array::Array;
-
 use super::{
     BinaryChunked, BooleanChunked, ChunkTransform, ChunkedArray, ListChunked, PolarsNumericType,
     SeriesTrait, StringChunked,
@@ -7,6 +5,8 @@ use super::{
 use crate::prelude::AnyValue;
 use crate::series::implementations::SeriesWrap;
 use crate::series::{IntoSeries, Series};
+use arrow::array::Array;
+use polars_utils::pl_str::PlSmallStr;
 
 impl<T: PolarsNumericType + 'static> ChunkTransform for ChunkedArray<T>
 where
@@ -28,7 +28,7 @@ where
             })
             .collect();
 
-        let raw_s = Series::from_any_values("".into(), &vec, true)?;
+        let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
         raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
     }
 }
@@ -45,7 +45,8 @@ impl ChunkTransform for StringChunked {
             .map(|(i, value)| lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)]))
             .collect();
 
-        Series::from_any_values("".into(), &vec, true)
+        let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
+        raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
     }
 }
 
@@ -64,7 +65,8 @@ impl ChunkTransform for BinaryChunked {
             .map(|(i, value)| lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)]))
             .collect();
 
-        Series::from_any_values("".into(), &vec, true)
+        let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
+        raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
     }
 }
 
@@ -94,7 +96,8 @@ impl ChunkTransform for ListChunked {
             .map(|(i, value)| lambda.eval_any(&[array_to_any(value), AnyValue::Int32(i as i32)]))
             .collect();
 
-        Series::from_any_values("".into(), &vec, true)
+        let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
+        raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
     }
 }
 
@@ -113,6 +116,7 @@ impl ChunkTransform for BooleanChunked {
             .map(|(i, value)| lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)]))
             .collect();
 
-        Series::from_any_values("".into(), &vec, true)
+        let raw_s = Series::from_any_values(PlSmallStr::EMPTY, &vec, true)?;
+        raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/transform.rs
+++ b/crates/polars-core/src/chunked_array/ops/transform.rs
@@ -32,7 +32,7 @@ where
         Series::from_any_values_and_dtype(
             PlSmallStr::EMPTY,
             &vec,
-            &lambda.return_type().unwrap_or(self.dtype().clone()),
+            &lambda.return_type(self.dtype())?,
             true,
         )
     }
@@ -53,7 +53,7 @@ impl ChunkTransform for StringChunked {
         Series::from_any_values_and_dtype(
             PlSmallStr::EMPTY,
             &vec,
-            &lambda.return_type().unwrap_or(self.dtype().clone()),
+            &lambda.return_type(self.dtype())?,
             true,
         )
     }
@@ -77,7 +77,7 @@ impl ChunkTransform for BinaryChunked {
         Series::from_any_values_and_dtype(
             PlSmallStr::EMPTY,
             &vec,
-            &lambda.return_type().unwrap_or(self.dtype().clone()),
+            &lambda.return_type(self.dtype())?,
             true,
         )
     }
@@ -112,7 +112,7 @@ impl ChunkTransform for ListChunked {
         Series::from_any_values_and_dtype(
             PlSmallStr::EMPTY,
             &vec,
-            &lambda.return_type().unwrap_or(self.dtype().clone()),
+            &lambda.return_type(self.dtype())?,
             true,
         )
     }
@@ -136,7 +136,7 @@ impl ChunkTransform for BooleanChunked {
         Series::from_any_values_and_dtype(
             PlSmallStr::EMPTY,
             &vec,
-            &lambda.return_type().unwrap_or(self.dtype().clone()),
+            &lambda.return_type(self.dtype())?,
             true,
         )
     }

--- a/crates/polars-core/src/chunked_array/ops/transform.rs
+++ b/crates/polars-core/src/chunked_array/ops/transform.rs
@@ -29,7 +29,12 @@ where
             })
             .collect();
 
-        Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &vec, &lambda.return_type().unwrap_or(self.dtype().clone()), true)
+        Series::from_any_values_and_dtype(
+            PlSmallStr::EMPTY,
+            &vec,
+            &lambda.return_type().unwrap_or(self.dtype().clone()),
+            true,
+        )
     }
 }
 
@@ -42,12 +47,15 @@ impl ChunkTransform for StringChunked {
         let vec: Vec<AnyValue> = self
             .iter()
             .enumerate()
-            .map(|(i, value)| {
-                lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)])
-            })
+            .map(|(i, value)| lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)]))
             .collect();
 
-        Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &vec, &lambda.return_type().unwrap_or(self.dtype().clone()), true)
+        Series::from_any_values_and_dtype(
+            PlSmallStr::EMPTY,
+            &vec,
+            &lambda.return_type().unwrap_or(self.dtype().clone()),
+            true,
+        )
     }
 }
 
@@ -66,7 +74,12 @@ impl ChunkTransform for BinaryChunked {
             .map(|(i, value)| lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)]))
             .collect();
 
-        Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &vec, &lambda.return_type().unwrap_or(self.dtype().clone()), true)
+        Series::from_any_values_and_dtype(
+            PlSmallStr::EMPTY,
+            &vec,
+            &lambda.return_type().unwrap_or(self.dtype().clone()),
+            true,
+        )
     }
 }
 
@@ -96,7 +109,12 @@ impl ChunkTransform for ListChunked {
             .map(|(i, value)| lambda.eval_any(&[array_to_any(value), AnyValue::Int32(i as i32)]))
             .collect();
 
-        Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &vec, &lambda.return_type().unwrap_or(self.dtype().clone()), true)
+        Series::from_any_values_and_dtype(
+            PlSmallStr::EMPTY,
+            &vec,
+            &lambda.return_type().unwrap_or(self.dtype().clone()),
+            true,
+        )
     }
 }
 
@@ -114,7 +132,12 @@ impl ChunkTransform for BooleanChunked {
             .enumerate()
             .map(|(i, value)| lambda.eval_any(&[value.into(), AnyValue::Int32(i as i32)]))
             .collect();
-        
-        Series::from_any_values_and_dtype(PlSmallStr::EMPTY, &vec, &lambda.return_type().unwrap_or(self.dtype().clone()), true)
+
+        Series::from_any_values_and_dtype(
+            PlSmallStr::EMPTY,
+            &vec,
+            &lambda.return_type().unwrap_or(self.dtype().clone()),
+            true,
+        )
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/transform.rs
+++ b/crates/polars-core/src/chunked_array/ops/transform.rs
@@ -28,7 +28,8 @@ where
             })
             .collect();
 
-        Series::from_any_values("".into(), &vec, true)
+        let raw_s = Series::from_any_values("".into(), &vec, true)?;
+        raw_s.cast(&lambda.return_type().unwrap_or(self.dtype().clone()))
     }
 }
 

--- a/crates/polars-core/src/series/implementations/floats.rs
+++ b/crates/polars-core/src/series/implementations/floats.rs
@@ -385,18 +385,19 @@ impl_dyn_series!(Float64Chunked);
 
 #[cfg(test)]
 mod tests {
-    use crate::series::{ChunkedArray, Float32Type, IntoSeries, LambdaExpression};
+    use crate::datatypes::Float64Type;
+    use crate::series::{ChunkedArray, IntoSeries, LambdaExpression};
 
     #[test]
     fn test_transform_float() {
         // here we test integer conversion
         // and thats we implemented transform on integer types
-        let series = ChunkedArray::<Float32Type>::from_vec("array".into(), vec![0.1, 0.2, 0.3])
+        let series = ChunkedArray::<Float64Type>::from_vec("array".into(), vec![0.1, 0.2, 0.3])
             .into_series();
 
         let lambda = LambdaExpression::Add(
             Box::new(LambdaExpression::Variable(0)),
-            Box::new(LambdaExpression::Int64(1)),
+            Box::new(LambdaExpression::Float64(1.0)),
         );
 
         let transformed = series.transform(&lambda);
@@ -405,7 +406,7 @@ mod tests {
 
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
-        let result = transformed.f32();
+        let result = transformed.f64();
 
         assert!(result.is_ok());
 

--- a/crates/polars-core/src/series/implementations/mod.rs
+++ b/crates/polars-core/src/series/implementations/mod.rs
@@ -569,7 +569,7 @@ mod tests {
 
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
-        let result = transformed.i32();
+        let result = transformed.i64();
 
         assert!(result.is_ok());
 
@@ -578,7 +578,7 @@ mod tests {
 
     #[test]
     fn test_transform_numeric_different_type() {
-        // here we test that lambda can return complitly different type
+        // here we test that lambda can return completely different type
         let series =
             ChunkedArray::<Int32Type>::from_vec("array".into(), vec![1, 2, 3]).into_series();
 
@@ -628,7 +628,7 @@ mod tests {
 
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
-        let result = transformed.i32();
+        let result = transformed.i64();
 
         assert!(result.is_ok());
 
@@ -652,7 +652,7 @@ mod tests {
 
         let transformed = transformed.unwrap();
         eprintln!("{:?}", transformed.dtype());
-        let result = transformed.i32();
+        let result = transformed.i64();
 
         assert!(result.is_ok());
 

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -112,8 +112,10 @@ impl ListFunction {
             FilterByFunc(_) => mapper.with_same_dtype(),
             SortByFunc(_, _) => mapper.with_same_dtype(),
             Transform(lambda) => mapper.try_map_dtype(|dt| match dt {
-                DataType::List(dtype) => Ok(DataType::List(lambda.return_type(&dtype).unwrap().into())),
-                _ => Ok(lambda.return_type(&dt).unwrap()), // TODO: transform can produce different type
+                DataType::List(dtype) => {
+                    Ok(DataType::List(lambda.return_type(&dtype).unwrap().into()))
+                },
+                _ => Ok(lambda.return_type(&dt).unwrap()),
             }),
             FlarionSlice => mapper.with_same_dtype(),
         }

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -108,13 +108,13 @@ impl ListFunction {
             #[cfg(feature = "dtype-array")]
             ToArray(width) => mapper.try_map_dtype(|dt| map_list_dtype_to_array_dtype(dt, *width)),
             NUnique => mapper.with_dtype(IDX_DTYPE),
-            // Flarion functinos
+            // Flarion functions
             FilterByFunc(_) => mapper.with_same_dtype(),
             SortByFunc(_, _) => mapper.with_same_dtype(),
-            Transform(lambda) => match lambda.return_type() {
-                Some(dtype) => mapper.with_dtype(dtype),
-                None => mapper.with_same_dtype(),
-            }, // TODO: transform can produce different type
+            Transform(lambda) => mapper.try_map_dtype(|dt| match dt {
+                DataType::List(dtype) => Ok(DataType::List(lambda.return_type(&dtype).unwrap().into())),
+                _ => Ok(lambda.return_type(&dt).unwrap()), // TODO: transform can produce different type
+            }),
             FlarionSlice => mapper.with_same_dtype(),
         }
     }

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -112,9 +112,7 @@ impl ListFunction {
             FilterByFunc(_) => mapper.with_same_dtype(),
             SortByFunc(_, _) => mapper.with_same_dtype(),
             Transform(lambda) => mapper.try_map_dtype(|dt| match dt {
-                DataType::List(dt) => {
-                    Ok(DataType::List(lambda.return_type(dt).unwrap().into()))
-                },
+                DataType::List(dt) => Ok(DataType::List(lambda.return_type(dt).unwrap().into())),
                 _ => Ok(lambda.return_type(dt).unwrap()),
             }),
             FlarionSlice => mapper.with_same_dtype(),

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -112,10 +112,10 @@ impl ListFunction {
             FilterByFunc(_) => mapper.with_same_dtype(),
             SortByFunc(_, _) => mapper.with_same_dtype(),
             Transform(lambda) => mapper.try_map_dtype(|dt| match dt {
-                DataType::List(dtype) => {
-                    Ok(DataType::List(lambda.return_type(&dtype).unwrap().into()))
+                DataType::List(dt) => {
+                    Ok(DataType::List(lambda.return_type(dt).unwrap().into()))
                 },
-                _ => Ok(lambda.return_type(&dt).unwrap()),
+                _ => Ok(lambda.return_type(dt).unwrap()),
             }),
             FlarionSlice => mapper.with_same_dtype(),
         }


### PR DESCRIPTION
This PR fixes 2 issues:
* correctly return the number of characters when calling length() in lambda. in case of unicode characters like: "😢" , spark expects actual characters to be 1 but polars returns 2.
* fix an issue where the dtype() of a series is incorrect when we use Array(Null) inside lambda expression.

implemented by accelerator in this PR [here](https://github.com/flarioncode/accelerator/pull/234).