### PR TITLE
fix: String to numerics cast should allow the following suffixes: "f", "F", "d", "D", "L"

### DIFF
--- a/crates/polars-arrow/src/compute/cast/binview_to.rs
+++ b/crates/polars-arrow/src/compute/cast/binview_to.rs
@@ -69,7 +69,13 @@ pub(super) fn binview_to_primitive<T>(
 where
     T: NativeType + Parse,
 {
-    let iter = from.iter().map(|x| x.and_then::<T, _>(|x| T::parse(x)));
+    let iter = from.iter().map(|x| x.and_then::<T, _>(|x| {
+        match x.last() {
+            // This was initially .map(to_ascii_lowercase) but apparently Spark doesn't do that for longs
+            Some(b'f') | Some(b'F') | Some(b'd') | Some(b'D') | Some(b'L') => T::parse(&x[..x.len() - 1]),
+            _ => T::parse(x)
+        }
+    }));
 
     PrimitiveArray::<T>::from_trusted_len_iter(iter).to(to.clone())
 }

--- a/crates/polars-arrow/src/compute/cast/binview_to.rs
+++ b/crates/polars-arrow/src/compute/cast/binview_to.rs
@@ -69,13 +69,17 @@ pub(super) fn binview_to_primitive<T>(
 where
     T: NativeType + Parse,
 {
-    let iter = from.iter().map(|x| x.and_then::<T, _>(|x| {
-        match x.last() {
-            // This was initially .map(to_ascii_lowercase) but apparently Spark doesn't do that for longs
-            Some(b'f') | Some(b'F') | Some(b'd') | Some(b'D') | Some(b'L') => T::parse(&x[..x.len() - 1]),
-            _ => T::parse(x)
-        }
-    }));
+    let iter = from.iter().map(|x| {
+        x.and_then::<T, _>(|x| {
+            match x.last() {
+                // This was initially .map(to_ascii_lowercase) but apparently Spark doesn't do that for longs
+                Some(b'f') | Some(b'F') | Some(b'd') | Some(b'D') | Some(b'L') => {
+                    T::parse(&x[..x.len() - 1])
+                },
+                _ => T::parse(x),
+            }
+        })
+    });
 
     PrimitiveArray::<T>::from_trusted_len_iter(iter).to(to.clone())
 }


### PR DESCRIPTION
I don't know why Spark doesn't support "l", but far be it from me to question my overlord