### PR TITLE
fix(rust): Add EuqalSafeNull and StringOwned support used by filter()

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -1,4 +1,5 @@
 use polars_compute::filter::filter as filter_fn;
+use std::str::from_utf8;
 
 #[cfg(feature = "object")]
 use crate::chunked_array::object::builder::ObjectChunkedBuilder;
@@ -23,6 +24,11 @@ fn is_length_comparison(lambda: &LambdaExpression) -> Option<(usize, bool)> {
             {
                 Some((*threshold as usize, true))
             },
+            (LambdaExpression::Length(var), LambdaExpression::Int32(threshold))
+            if matches!(&**var, LambdaExpression::Variable(_)) =>
+                {
+                    Some((*threshold as usize, true))
+                },
             _ => None,
         },
         LambdaExpression::LessThan(left, right) => match (left.as_ref(), right.as_ref()) {
@@ -31,6 +37,11 @@ fn is_length_comparison(lambda: &LambdaExpression) -> Option<(usize, bool)> {
             {
                 Some((*threshold as usize, false))
             },
+            (LambdaExpression::Length(var), LambdaExpression::Int32(threshold))
+            if matches!(&**var, LambdaExpression::Variable(_)) =>
+                {
+                    Some((*threshold as usize, false))
+                },
             _ => None,
         },
         _ => None,
@@ -173,7 +184,10 @@ impl ChunkFilter<StringType> for StringChunked {
             // Use optimized length-based filtering
             let mask = self.iter().map(|opt_val| match opt_val {
                 Some(val) => {
-                    let len = val.len();
+                    let len = match from_utf8(val.as_bytes()) {
+                        Ok(s) => s.chars().count(),
+                        Err(_) => val.len(),
+                    };
                     if is_greater {
                         len > threshold
                     } else {
@@ -249,7 +263,7 @@ impl ChunkFilter<BinaryType> for BinaryChunked {
                 AnyValue::Boolean(b) => b,
                 _ => panic!("Lambda must return boolean values"),
             },
-            None => false,
+            None => true,
         });
 
         let bool_mask = BooleanChunked::from_iter_values(self.name().clone(), mask);

--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -73,7 +73,7 @@ where
     T: PolarsNumericType,
 {
     pub fn filter_with_func(&self, lambda: &LambdaExpression) -> PolarsResult<ChunkedArray<T>> {
-        let mut keep_nulls= false; // filter out nulls by default
+        let mut keep_nulls = false; // filter out nulls by default
 
         // in spark, if expression is isnull() then it expects to keep the nulls when it encounters one.
         if let LambdaExpression::IsNull(_) = lambda {
@@ -81,16 +81,12 @@ where
         }
 
         // Evaluate each element using eval_numeric
-        let mask = self.iter().map(|opt_val| {
-            match opt_val {
-                Some(val) => {
-                    match lambda.eval_numeric::<T>(&[&val]) {
-                        AnyValue::Boolean(b) => b,
-                        _ => panic!("Lambda must return boolean values"),
-                    }
-                },
-                None => keep_nulls,
-            }
+        let mask = self.iter().map(|opt_val| match opt_val {
+            Some(val) => match lambda.eval_numeric::<T>(&[&val]) {
+                AnyValue::Boolean(b) => b,
+                _ => panic!("Lambda must return boolean values"),
+            },
+            None => keep_nulls,
         });
 
         let bool_mask = BooleanChunked::from_iter_values(self.name().clone(), mask);

--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -73,13 +73,26 @@ where
     T: PolarsNumericType,
 {
     pub fn filter_with_func(&self, lambda: &LambdaExpression) -> PolarsResult<ChunkedArray<T>> {
-        let mask = self.iter().map(|opt_val| match opt_val {
-            Some(val) => match lambda.eval_numeric::<T>(&[&val]) {
-                AnyValue::Boolean(b) => b,
-                _ => panic!("Lambda must return boolean values"),
-            },
-            None => false,
+        let mut keep_nulls= false; // filter out nulls by default
+
+        // in spark, if expression is isnull() then it expects to keep the nulls when it encounters one.
+        if let LambdaExpression::IsNull(_) = lambda {
+            keep_nulls = true;
+        }
+
+        // Evaluate each element using eval_numeric
+        let mask = self.iter().map(|opt_val| {
+            match opt_val {
+                Some(val) => {
+                    match lambda.eval_numeric::<T>(&[&val]) {
+                        AnyValue::Boolean(b) => b,
+                        _ => panic!("Lambda must return boolean values"),
+                    }
+                },
+                None => keep_nulls,
+            }
         });
+
         let bool_mask = BooleanChunked::from_iter_values(self.name().clone(), mask);
         self.filter(&bool_mask)
     }

--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -1,5 +1,6 @@
-use polars_compute::filter::filter as filter_fn;
 use std::str::from_utf8;
+
+use polars_compute::filter::filter as filter_fn;
 
 #[cfg(feature = "object")]
 use crate::chunked_array::object::builder::ObjectChunkedBuilder;
@@ -25,10 +26,10 @@ fn is_length_comparison(lambda: &LambdaExpression) -> Option<(usize, bool)> {
                 Some((*threshold as usize, true))
             },
             (LambdaExpression::Length(var), LambdaExpression::Int32(threshold))
-            if matches!(&**var, LambdaExpression::Variable(_)) =>
-                {
-                    Some((*threshold as usize, true))
-                },
+                if matches!(&**var, LambdaExpression::Variable(_)) =>
+            {
+                Some((*threshold as usize, true))
+            },
             _ => None,
         },
         LambdaExpression::LessThan(left, right) => match (left.as_ref(), right.as_ref()) {
@@ -38,10 +39,10 @@ fn is_length_comparison(lambda: &LambdaExpression) -> Option<(usize, bool)> {
                 Some((*threshold as usize, false))
             },
             (LambdaExpression::Length(var), LambdaExpression::Int32(threshold))
-            if matches!(&**var, LambdaExpression::Variable(_)) =>
-                {
-                    Some((*threshold as usize, false))
-                },
+                if matches!(&**var, LambdaExpression::Variable(_)) =>
+            {
+                Some((*threshold as usize, false))
+            },
             _ => None,
         },
         _ => None,

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -2,18 +2,17 @@ use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 use std::str::from_utf8;
 
-use arrow::array::ViewType;
-use num_traits::ToBytes;
-use polars_error::{PolarsError, PolarsResult};
-#[cfg(feature = "serde-lazy")]
-use serde::{Deserialize, Serialize};
-
 use super::flarion_funcs::{flarion_get_char_position, flarion_substring};
 use super::DataType;
 use crate::datatypes::{AnyValue, PolarsNumericType};
 use crate::prelude::Array;
 use crate::series::Series;
 use crate::utils::dtypes_to_supertype;
+use arrow::array::ViewType;
+use num_traits::ToBytes;
+use polars_error::{PolarsError, PolarsResult};
+#[cfg(feature = "serde-lazy")]
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
@@ -317,10 +316,34 @@ impl LambdaExpression {
             LambdaExpression::StaticStr(v) => AnyValue::String(v),
             LambdaExpression::Variable(idx) => (*args[*idx]).into(),
             LambdaExpression::GreaterThan(left, right) => {
-                AnyValue::Boolean(left.eval_numeric::<T>(args) > right.eval_numeric::<T>(args))
+                let left = left.eval_numeric::<T>(args);
+                let right = right.eval_numeric::<T>(args);
+                
+                // Special case for Int8/Int16 and Int32 when using Array[Byte]/Array[Short]
+                match (&left, &right) {
+                    (AnyValue::Int8(left), AnyValue::Int32(right)) => {
+                        AnyValue::Boolean((*left as i32) > *right)
+                    },
+                    (AnyValue::Int16(left), AnyValue::Int32(right)) => {
+                        AnyValue::Boolean((*left as i32) > *right)
+                    },
+                   _ => AnyValue::Boolean(left > right)
+                }
             },
             LambdaExpression::LessThan(left, right) => {
-                AnyValue::Boolean(left.eval_numeric::<T>(args) < right.eval_numeric::<T>(args))
+                let left = left.eval_numeric::<T>(args);
+                let right = right.eval_numeric::<T>(args);
+
+                // Special case for Int8/Int16 and Int32 when using Array[Byte]/Array[Short]
+                match (&left, &right) {
+                    (AnyValue::Int8(left), AnyValue::Int32(right)) => {
+                        AnyValue::Boolean((*left as i32) < *right)
+                    },
+                    (AnyValue::Int16(left), AnyValue::Int32(right)) => {
+                        AnyValue::Boolean((*left as i32) < *right)
+                    },
+                    _ => AnyValue::Boolean(left < right)
+                }
             },
             LambdaExpression::IfThenElse(cond, truthy, falsy) => {
                 if unsafe {

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -2,17 +2,18 @@ use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 use std::str::from_utf8;
 
+use arrow::array::ViewType;
+use num_traits::ToBytes;
+use polars_error::{PolarsError, PolarsResult};
+#[cfg(feature = "serde-lazy")]
+use serde::{Deserialize, Serialize};
+
 use super::flarion_funcs::{flarion_get_char_position, flarion_substring};
 use super::DataType;
 use crate::datatypes::{AnyValue, PolarsNumericType};
 use crate::prelude::Array;
 use crate::series::Series;
 use crate::utils::dtypes_to_supertype;
-use arrow::array::ViewType;
-use num_traits::ToBytes;
-use polars_error::{PolarsError, PolarsResult};
-#[cfg(feature = "serde-lazy")]
-use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
@@ -318,8 +319,9 @@ impl LambdaExpression {
             LambdaExpression::GreaterThan(left, right) => {
                 let left = left.eval_numeric::<T>(args);
                 let right = right.eval_numeric::<T>(args);
-                
+
                 // Special case for Int8/Int16 and Int32 when using Array[Byte]/Array[Short]
+                // For example: Array[Byte](77) < 5
                 match (&left, &right) {
                     (AnyValue::Int8(left), AnyValue::Int32(right)) => {
                         AnyValue::Boolean((*left as i32) > *right)
@@ -327,7 +329,7 @@ impl LambdaExpression {
                     (AnyValue::Int16(left), AnyValue::Int32(right)) => {
                         AnyValue::Boolean((*left as i32) > *right)
                     },
-                   _ => AnyValue::Boolean(left > right)
+                    _ => AnyValue::Boolean(left > right),
                 }
             },
             LambdaExpression::LessThan(left, right) => {
@@ -335,6 +337,7 @@ impl LambdaExpression {
                 let right = right.eval_numeric::<T>(args);
 
                 // Special case for Int8/Int16 and Int32 when using Array[Byte]/Array[Short]
+                // For example: Array[Byte](77) < 5
                 match (&left, &right) {
                     (AnyValue::Int8(left), AnyValue::Int32(right)) => {
                         AnyValue::Boolean((*left as i32) < *right)
@@ -342,7 +345,7 @@ impl LambdaExpression {
                     (AnyValue::Int16(left), AnyValue::Int32(right)) => {
                         AnyValue::Boolean((*left as i32) < *right)
                     },
-                    _ => AnyValue::Boolean(left < right)
+                    _ => AnyValue::Boolean(left < right),
                 }
             },
             LambdaExpression::IfThenElse(cond, truthy, falsy) => {

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -2,17 +2,17 @@ use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 use std::str::from_utf8;
 
-use num_traits::ToBytes;
-use polars_error::{PolarsError, PolarsResult};
-#[cfg(feature = "serde-lazy")]
-use serde::{Deserialize, Serialize};
-
 use super::flarion_funcs::{flarion_get_char_position, flarion_substring};
 use super::DataType;
 use crate::datatypes::{AnyValue, PolarsNumericType};
 use crate::prelude::Array;
 use crate::series::Series;
 use crate::utils::dtypes_to_supertype;
+use arrow::array::ViewType;
+use num_traits::ToBytes;
+use polars_error::{PolarsError, PolarsResult};
+#[cfg(feature = "serde-lazy")]
+use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
@@ -105,7 +105,10 @@ pub fn flarion_substring_anyvalue<'a>(
         (AnyValue::String(s), AnyValue::Int32(from), AnyValue::Int32(len)) => {
             AnyValue::StringOwned(flarion_substring(s, from, len).into())
         },
-        _ => AnyValue::Null,
+        (AnyValue::Binary(s), AnyValue::Int32(from), AnyValue::Int32(len)) => {
+            AnyValue::BinaryOwned(flarion_substring(from_utf8(s).unwrap(), from, len).to_bytes().into())
+        },
+        _ => unreachable!(),
     }
 }
 
@@ -552,6 +555,9 @@ impl LambdaExpression {
                         },
                         (AnyValue::Binary(s), AnyValue::String(oat)) => {
                             AnyValue::Int32(flarion_get_char_position(from_utf8(s).unwrap(), oat))
+                        },
+                        (AnyValue::BinaryOwned(s), AnyValue::String(oat)) => {
+                            AnyValue::Int32(flarion_get_char_position(from_utf8(&s).unwrap(), oat))
                         },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
+use std::str::from_utf8;
 
 use num_traits::ToBytes;
 use polars_error::{PolarsError, PolarsResult};
@@ -475,8 +476,12 @@ impl LambdaExpression {
             },
             LambdaExpression::Length(expr) => match expr.eval_slice(args) {
                 AnyValue::Null => AnyValue::Null,
-                AnyValue::Binary(bytes) => AnyValue::Int32(bytes.len() as i32),
-                AnyValue::String(s) => AnyValue::Int32(s.len() as i32),
+                AnyValue::Binary(bytes) => {
+                    // case we have a binary slice, convert to utf8 as spark expects
+                    let new_str = from_utf8(bytes).unwrap();
+                    AnyValue::Int32(new_str.chars().count() as i32)
+                },
+                AnyValue::String(s) => AnyValue::Int32(s.chars().count() as i32),
                 AnyValue::List(arr) => AnyValue::Int32(arr.len() as i32),
                 _ => AnyValue::Int32(1),
             },
@@ -506,6 +511,9 @@ impl LambdaExpression {
                     match (s, pat) {
                         (AnyValue::String(s), AnyValue::String(pat)) => {
                             AnyValue::Int32(flarion_get_char_position(s, pat))
+                        },
+                        (AnyValue::Binary(s), AnyValue::String(oat)) => {
+                            AnyValue::Int32(flarion_get_char_position(from_utf8(s).unwrap(), oat))
                         },
                         _ => std::hint::unreachable_unchecked(), // tell the compiler it's unreachable
                     }
@@ -601,6 +609,7 @@ impl LambdaExpression {
                 left.add(&right.cast(&left.dtype()))
             },
             LambdaExpression::IsNull(expr) => {
+                println!("evaluating is null");
                 if expr.eval_any(args).is_null() {
                     AnyValue::Boolean(true)
                 } else {

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -609,7 +609,6 @@ impl LambdaExpression {
                 left.add(&right.cast(&left.dtype()))
             },
             LambdaExpression::IsNull(expr) => {
-                println!("evaluating is null");
                 if expr.eval_any(args).is_null() {
                     AnyValue::Boolean(true)
                 } else {

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -550,14 +550,31 @@ impl LambdaExpression {
                 match expr.eval_slice(args) {
                     AnyValue::Null => AnyValue::Null,
                     AnyValue::Binary(bytes) => {
-                        // case we have a binary slice, convert to utf8 as spark expects
-                        let new_str = from_utf8(bytes).unwrap();
-                        AnyValue::Int32(new_str.chars().count() as i32)
+                        println!("binary: {:?}", bytes);
+                        // case we have a binary slice, try to convert to utf8 as spark expects, else return length of bytes
+                        match from_utf8(bytes) {
+                            Ok(new_str) => {
+                                println!("utf8: {:?}", new_str);
+                                AnyValue::Int32(new_str.chars().count() as i32)
+                            },
+                            Err(_) => {
+                                AnyValue::Int32(bytes.len() as i32)
+                            },
+                        }
                     },
                     AnyValue::BinaryOwned(bytes) => {
+                        println!("owned binary: {:?}", bytes);
                         // case we have a binary slice, convert to utf8 as spark expects
-                        let new_str = from_utf8(&bytes).unwrap();
-                        AnyValue::Int32(new_str.chars().count() as i32)
+                        match from_utf8(&bytes) {
+                            Ok(utf8_str) => {
+                                // Valid UTF-8 string - count characters like Spark
+                                AnyValue::Int32(utf8_str.chars().count() as i32)
+                            },
+                            Err(_) => {
+                                // Not valid UTF-8 - return byte length
+                                AnyValue::Int32(bytes.len() as i32)
+                            }
+                        }
                     },
                     AnyValue::String(s) => AnyValue::Int32(s.chars().count() as i32),
                     AnyValue::List(arr) => AnyValue::Int32(arr.len() as i32),

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -2,17 +2,18 @@ use std::borrow::Cow;
 use std::hash::{Hash, Hasher};
 use std::str::from_utf8;
 
+use arrow::array::ViewType;
+use num_traits::ToBytes;
+use polars_error::{PolarsError, PolarsResult};
+#[cfg(feature = "serde-lazy")]
+use serde::{Deserialize, Serialize};
+
 use super::flarion_funcs::{flarion_get_char_position, flarion_substring};
 use super::DataType;
 use crate::datatypes::{AnyValue, PolarsNumericType};
 use crate::prelude::Array;
 use crate::series::Series;
 use crate::utils::dtypes_to_supertype;
-use arrow::array::ViewType;
-use num_traits::ToBytes;
-use polars_error::{PolarsError, PolarsResult};
-#[cfg(feature = "serde-lazy")]
-use serde::{Deserialize, Serialize};
 
 #[derive(Clone, PartialEq, Debug)]
 #[cfg_attr(feature = "serde-lazy", derive(Serialize, Deserialize))]
@@ -37,7 +38,7 @@ pub enum LambdaExpression {
     Instr(Box<Self>, Box<Self>),
     Add(Box<Self>, Box<Self>),
     IsNull(Box<Self>),
-    EqualNullSafe(Box<Self>, Box<Self>)
+    EqualNullSafe(Box<Self>, Box<Self>),
 }
 
 impl Eq for LambdaExpression {}
@@ -106,7 +107,11 @@ pub fn flarion_substring_anyvalue<'a>(
             AnyValue::StringOwned(flarion_substring(s, from, len).into())
         },
         (AnyValue::Binary(s), AnyValue::Int32(from), AnyValue::Int32(len)) => {
-            AnyValue::BinaryOwned(flarion_substring(from_utf8(s).unwrap(), from, len).to_bytes().into())
+            AnyValue::BinaryOwned(
+                flarion_substring(from_utf8(s).unwrap(), from, len)
+                    .to_bytes()
+                    .into(),
+            )
         },
         _ => unreachable!(),
     }
@@ -293,7 +298,7 @@ impl LambdaExpression {
                 } else {
                     AnyValue::Boolean(left.eq(&right))
                 }
-            }
+            },
         }
     }
 
@@ -386,7 +391,7 @@ impl LambdaExpression {
                 } else {
                     AnyValue::Boolean(left.eq(&right))
                 }
-            }
+            },
         }
     }
 
@@ -479,7 +484,7 @@ impl LambdaExpression {
                 } else {
                     AnyValue::Boolean(left.eq(&right))
                 }
-            }
+            },
         }
     }
 
@@ -592,7 +597,7 @@ impl LambdaExpression {
                 } else {
                     AnyValue::Boolean(left.eq(&right))
                 }
-            }
+            },
         }
     }
 
@@ -687,7 +692,7 @@ impl LambdaExpression {
                 } else {
                     AnyValue::Boolean(left.eq(&right))
                 }
-            }
+            },
         }
     }
 

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -515,16 +515,23 @@ impl LambdaExpression {
                     falsy.eval_slice(args)
                 }
             },
-            LambdaExpression::Length(expr) => match expr.eval_slice(args) {
-                AnyValue::Null => AnyValue::Null,
-                AnyValue::Binary(bytes) => {
-                    // case we have a binary slice, convert to utf8 as spark expects
-                    let new_str = from_utf8(bytes).unwrap();
-                    AnyValue::Int32(new_str.chars().count() as i32)
-                },
-                AnyValue::String(s) => AnyValue::Int32(s.chars().count() as i32),
-                AnyValue::List(arr) => AnyValue::Int32(arr.len() as i32),
-                _ => AnyValue::Int32(1),
+            LambdaExpression::Length(expr) => {
+                match expr.eval_slice(args) {
+                    AnyValue::Null => AnyValue::Null,
+                    AnyValue::Binary(bytes) => {
+                        // case we have a binary slice, convert to utf8 as spark expects
+                        let new_str = from_utf8(bytes).unwrap();
+                        AnyValue::Int32(new_str.chars().count() as i32)
+                    },
+                    AnyValue::BinaryOwned(bytes) => {
+                        // case we have a binary slice, convert to utf8 as spark expects
+                        let new_str = from_utf8(&bytes).unwrap();
+                        AnyValue::Int32(new_str.chars().count() as i32)
+                    },
+                    AnyValue::String(s) => AnyValue::Int32(s.chars().count() as i32),
+                    AnyValue::List(arr) => AnyValue::Int32(arr.len() as i32),
+                    _ => AnyValue::Int32(1),
+                }
             },
             LambdaExpression::CaseWhen(cases, otherwise) => {
                 for (cond, value) in cases {

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -37,6 +37,7 @@ pub enum LambdaExpression {
     Instr(Box<Self>, Box<Self>),
     Add(Box<Self>, Box<Self>),
     IsNull(Box<Self>),
+    EqualNullSafe(Box<Self>, Box<Self>)
 }
 
 impl Eq for LambdaExpression {}
@@ -87,6 +88,10 @@ impl Hash for LambdaExpression {
                 second.hash(state);
             },
             LambdaExpression::IsNull(v) => v.hash(state),
+            LambdaExpression::EqualNullSafe(first, second) => {
+                first.hash(state);
+                second.hash(state);
+            },
         }
     }
 }
@@ -275,6 +280,17 @@ impl LambdaExpression {
                     AnyValue::Boolean(false)
                 }
             },
+            LambdaExpression::EqualNullSafe(left, right) => {
+                let left = left.eval_array(args);
+                let right = right.eval_array(args);
+                if left.is_null() && right.is_null() {
+                    AnyValue::Boolean(true)
+                } else if left.is_null() || right.is_null() {
+                    AnyValue::Boolean(false)
+                } else {
+                    AnyValue::Boolean(left.eq(&right))
+                }
+            }
         }
     }
 
@@ -357,6 +373,17 @@ impl LambdaExpression {
                     AnyValue::Boolean(false)
                 }
             },
+            LambdaExpression::EqualNullSafe(left, right) => {
+                let left = left.eval_numeric::<T>(args);
+                let right = right.eval_numeric::<T>(args);
+                if left.is_null() && right.is_null() {
+                    AnyValue::Boolean(true)
+                } else if left.is_null() || right.is_null() {
+                    AnyValue::Boolean(false)
+                } else {
+                    AnyValue::Boolean(left.eq(&right))
+                }
+            }
         }
     }
 
@@ -439,6 +466,17 @@ impl LambdaExpression {
                     AnyValue::Boolean(false)
                 }
             },
+            LambdaExpression::EqualNullSafe(left, right) => {
+                let left = left.eval_bool(args);
+                let right = right.eval_bool(args);
+                if left.is_null() && right.is_null() {
+                    AnyValue::Boolean(true)
+                } else if left.is_null() || right.is_null() {
+                    AnyValue::Boolean(false)
+                } else {
+                    AnyValue::Boolean(left.eq(&right))
+                }
+            }
         }
     }
 
@@ -531,6 +569,17 @@ impl LambdaExpression {
                     AnyValue::Boolean(false)
                 }
             },
+            LambdaExpression::EqualNullSafe(left, right) => {
+                let left = left.eval_slice(args);
+                let right = right.eval_slice(args);
+                if left.is_null() && right.is_null() {
+                    AnyValue::Boolean(true)
+                } else if left.is_null() || right.is_null() {
+                    AnyValue::Boolean(false)
+                } else {
+                    AnyValue::Boolean(left.eq(&right))
+                }
+            }
         }
     }
 
@@ -615,6 +664,17 @@ impl LambdaExpression {
                     AnyValue::Boolean(false)
                 }
             },
+            LambdaExpression::EqualNullSafe(left, right) => {
+                let left = left.eval_any(args);
+                let right = right.eval_any(args);
+                if left.is_null() && right.is_null() {
+                    AnyValue::Boolean(true)
+                } else if left.is_null() || right.is_null() {
+                    AnyValue::Boolean(false)
+                } else {
+                    AnyValue::Boolean(left.eq(&right))
+                }
+            }
         }
     }
 
@@ -656,6 +716,7 @@ impl LambdaExpression {
                 &right.return_type(input_type)?,
             ])?,
             LambdaExpression::IsNull(_) => DataType::Boolean,
+            LambdaExpression::EqualNullSafe(_, _) => DataType::Boolean,
         })
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -322,14 +322,14 @@ impl LambdaExpression {
 
                 // Special case for Int8/Int16 and Int32 when using Array[Byte]/Array[Short]
                 // For example: Array[Byte](77) < 5
-                match (&left, &right) {
+                match (left, right) {
                     (AnyValue::Int8(left), AnyValue::Int32(right)) => {
-                        AnyValue::Boolean((*left as i32) > *right)
+                        AnyValue::Boolean((left as i32) > right)
                     },
                     (AnyValue::Int16(left), AnyValue::Int32(right)) => {
-                        AnyValue::Boolean((*left as i32) > *right)
+                        AnyValue::Boolean((left as i32) > right)
                     },
-                    _ => AnyValue::Boolean(left > right),
+                    (left, right) => AnyValue::Boolean(left > right),
                 }
             },
             LambdaExpression::LessThan(left, right) => {

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -550,30 +550,17 @@ impl LambdaExpression {
                 match expr.eval_slice(args) {
                     AnyValue::Null => AnyValue::Null,
                     AnyValue::Binary(bytes) => {
-                        println!("binary: {:?}", bytes);
                         // case we have a binary slice, try to convert to utf8 as spark expects, else return length of bytes
                         match from_utf8(bytes) {
-                            Ok(new_str) => {
-                                println!("utf8: {:?}", new_str);
-                                AnyValue::Int32(new_str.chars().count() as i32)
-                            },
-                            Err(_) => {
-                                AnyValue::Int32(bytes.len() as i32)
-                            },
+                            Ok(new_str) => AnyValue::Int32(new_str.chars().count() as i32),
+                            Err(_) => AnyValue::Int32(bytes.len() as i32),
                         }
                     },
                     AnyValue::BinaryOwned(bytes) => {
-                        println!("owned binary: {:?}", bytes);
                         // case we have a binary slice, convert to utf8 as spark expects
                         match from_utf8(&bytes) {
-                            Ok(utf8_str) => {
-                                // Valid UTF-8 string - count characters like Spark
-                                AnyValue::Int32(utf8_str.chars().count() as i32)
-                            },
-                            Err(_) => {
-                                // Not valid UTF-8 - return byte length
-                                AnyValue::Int32(bytes.len() as i32)
-                            }
+                            Ok(utf8_str) => AnyValue::Int32(utf8_str.chars().count() as i32),
+                            Err(_) => AnyValue::Int32(bytes.len() as i32),
                         }
                     },
                     AnyValue::String(s) => AnyValue::Int32(s.chars().count() as i32),

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -309,6 +309,11 @@ pub trait ListNameSpaceImpl: AsList {
                     let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
                     Ok(filtered_ca.into_series())
                 },
+                DataType::Binary => {
+                    let ca = s_ref.binary()?;
+                    let filtered_ca = ca.filter_with_func(&lambda_expressions)?;
+                    Ok(filtered_ca.into_series())
+                },
                 _ => {
                     polars_bail!(
                         ComputeError: "filter_with_func not implemented for type: {:?}",


### PR DESCRIPTION
This PR adds support types and expressions used by filter()

# Added
- [x] EqualNullSafe expression support
- [x] StringOwned type support in Length/Substring/InStr
- [x] Better null filtering checks 
- [x] Better support for Binary Data filtering 

Integration tests PR for filter() can be found [here](https://github.com/flarioncode/accelerator/pull/250)