### PR TITLE
fix: Edit check_expand_literals to expand literals when the expression is just literals or scalars

### DIFF
--- a/crates/polars-mem-engine/src/executors/projection_utils.rs
+++ b/crates/polars-mem-engine/src/executors/projection_utils.rs
@@ -268,7 +268,7 @@ fn is_reducing_expr(phys_expr: &dyn PhysicalExpr) -> bool {
             _ => false,
         }
     } else {
-        false
+        phys_expr.is_scalar()
     }
 }
 
@@ -290,6 +290,14 @@ pub(super) fn check_expand_literals(
     // If any expression is not a literal OR any is reducing -> start with height 0
     let all_literals = phys_expr
         .iter()
+        .inspect(|e| {
+            println!("Expression: {:?}", e.as_expression());
+            println!("  type: {}", std::any::type_name_of_val(e));
+            println!("  is_literal: {}", e.is_literal());
+            println!("  is_scalar: {}", e.is_scalar());
+            println!("  is_reducing: {}", is_reducing_expr(e.as_ref()));
+            println!("---");
+        })
         .all(|e| (e.is_literal() || e.is_scalar()) && !is_reducing_expr(e.as_ref()));
 
     let mut df_height = if all_literals { df.height() } else { 0 };

--- a/crates/polars-mem-engine/src/executors/projection_utils.rs
+++ b/crates/polars-mem-engine/src/executors/projection_utils.rs
@@ -246,7 +246,7 @@ pub(super) fn evaluate_physical_expressions(
 // In cases of aggregate or window expressions we do not want to expand.
 fn is_reducing_expr(phys_expr: &dyn PhysicalExpr) -> bool {
     if let Some(expr) = phys_expr.as_expression() {
-        matches!(expr, Expr::Agg(_) | Expr::Window { .. } ) 
+        matches!(expr, Expr::Agg(_) | Expr::Window { .. })
     } else {
         false
     }

--- a/crates/polars-mem-engine/src/executors/projection_utils.rs
+++ b/crates/polars-mem-engine/src/executors/projection_utils.rs
@@ -246,12 +246,10 @@ pub(super) fn evaluate_physical_expressions(
 // In cases of reducing expressions we do not want to expand.
 fn is_reducing_expr(phys_expr: &dyn PhysicalExpr) -> bool {
     if let Some(expr) = phys_expr.as_expression() {
-        match expr {
-            Expr::Agg(_) => true,
-            _ => false,
-        }
+        matches!(expr, Expr::Agg(_))
     } else {
-        // If None, we just check if the expression is a scalar.
+        // If we can't determine the expression type but it's scalar,
+        // assume it's reducing to be safe
         phys_expr.is_scalar()
     }
 }

--- a/crates/polars-mem-engine/src/executors/projection_utils.rs
+++ b/crates/polars-mem-engine/src/executors/projection_utils.rs
@@ -243,6 +243,15 @@ pub(super) fn evaluate_physical_expressions(
     Ok(selected_columns)
 }
 
+// In cases of aggregate expressions we do not want to expand.
+fn is_aggregate_expr(phys_expr: &dyn PhysicalExpr) -> bool {
+    if let Some(expr) = phys_expr.as_expression() {
+        matches!(expr, Expr::Agg(_))
+    } else {
+        false
+    }
+}
+
 pub(super) fn check_expand_literals(
     df: &DataFrame,
     phys_expr: &[Arc<dyn PhysicalExpr>],
@@ -256,16 +265,23 @@ pub(super) fn check_expand_literals(
     let duplicate_check = options.duplicate_check;
     let should_broadcast = options.should_broadcast;
 
-    // When we have CSE we cannot verify scalars yet.
-    let verify_scalar = if !df.get_columns().is_empty() {
-        !df.get_columns()[df.width() - 1]
-            .name()
-            .starts_with(CSE_REPLACED)
-    } else {
-        true
-    };
+    // In aggregate expressions we can get all literals but not want to expand literals.
+    let all_literals = phys_expr
+        .iter()
+        .all(|e| (e.is_literal() || e.is_scalar()) && !is_aggregate_expr(e.as_ref()));
 
-    let mut df_height = 0;
+    let verify_scalar = all_literals
+        || if !df.get_columns().is_empty() {
+            // When we have CSE (in the non-literal case) we cannot verify scalars yet.
+            !df.get_columns()[df.width() - 1]
+                .name()
+                .starts_with(CSE_REPLACED)
+        } else {
+            true
+        };
+
+    // When all expressions are literals, use input df height
+    let mut df_height = if all_literals { df.height() } else { 0 };
     let mut has_empty = false;
     let mut all_equal_len = true;
     {
@@ -274,7 +290,9 @@ pub(super) fn check_expand_literals(
             let len = s.len();
             has_empty |= len == 0;
             df_height = std::cmp::max(df_height, len);
-            if len != first_len {
+
+            let target_len = if all_literals { df.height() } else { first_len };
+            if len != target_len {
                 all_equal_len = false;
             }
             let name = s.name();

--- a/crates/polars-mem-engine/src/executors/projection_utils.rs
+++ b/crates/polars-mem-engine/src/executors/projection_utils.rs
@@ -247,27 +247,11 @@ pub(super) fn evaluate_physical_expressions(
 fn is_reducing_expr(phys_expr: &dyn PhysicalExpr) -> bool {
     if let Some(expr) = phys_expr.as_expression() {
         match expr {
-            Expr::Window { .. } => false,
-            // Only match pure aggregations that reduce cardinality
-            Expr::Agg(agg) => matches!(
-                agg,
-                AggExpr::Min { .. }
-                    | AggExpr::Max { .. }
-                    | AggExpr::Median { .. }
-                    | AggExpr::Mean { .. }
-                    | AggExpr::Sum { .. }
-                    | AggExpr::Std { .. }
-                    | AggExpr::Var { .. }
-                    | AggExpr::NUnique { .. }
-                    | AggExpr::First { .. }
-                    | AggExpr::Last { .. }
-                    | AggExpr::Count { .. }
-                    | AggExpr::Quantile { .. }
-                    | AggExpr::Implode { .. }
-            ),
+            Expr::Agg(_) => true,
             _ => false,
         }
     } else {
+        // If None, we just check if the expression is a scalar.
         phys_expr.is_scalar()
     }
 }
@@ -290,14 +274,6 @@ pub(super) fn check_expand_literals(
     // If any expression is not a literal OR any is reducing -> start with height 0
     let all_literals = phys_expr
         .iter()
-        .inspect(|e| {
-            println!("Expression: {:?}", e.as_expression());
-            println!("  type: {}", std::any::type_name_of_val(e));
-            println!("  is_literal: {}", e.is_literal());
-            println!("  is_scalar: {}", e.is_scalar());
-            println!("  is_reducing: {}", is_reducing_expr(e.as_ref()));
-            println!("---");
-        })
         .all(|e| (e.is_literal() || e.is_scalar()) && !is_reducing_expr(e.as_ref()));
 
     let mut df_height = if all_literals { df.height() } else { 0 };

--- a/crates/polars-mem-engine/src/executors/projection_utils.rs
+++ b/crates/polars-mem-engine/src/executors/projection_utils.rs
@@ -243,10 +243,28 @@ pub(super) fn evaluate_physical_expressions(
     Ok(selected_columns)
 }
 
-// In cases of aggregate or window expressions we do not want to expand.
+// In cases of reducing expressions we do not want to expand.
 fn is_reducing_expr(phys_expr: &dyn PhysicalExpr) -> bool {
     if let Some(expr) = phys_expr.as_expression() {
-        matches!(expr, Expr::Agg(_) | Expr::Window { .. })
+        match expr {
+            // Only match pure aggregations that reduce cardinality
+            Expr::Agg(agg) => matches!(
+                agg,
+                AggExpr::Min { .. }
+                    | AggExpr::Max { .. }
+                    | AggExpr::Median { .. }
+                    | AggExpr::Mean { .. }
+                    | AggExpr::Sum { .. }
+                    | AggExpr::Std { .. }
+                    | AggExpr::Var { .. }
+                    | AggExpr::NUnique { .. }
+                    | AggExpr::First { .. }
+                    | AggExpr::Last { .. }
+                    | AggExpr::Count { .. }
+                    | AggExpr::Quantile { .. }
+            ),
+            _ => false,
+        }
     } else {
         false
     }
@@ -265,10 +283,14 @@ pub(super) fn check_expand_literals(
     let duplicate_check = options.duplicate_check;
     let should_broadcast = options.should_broadcast;
 
-    // In aggregate expressions we can get all literals but not want to expand literals.
+    // The logic flow is:
+    // If all expressions are literals AND none are reducing -> use input df height
+    // If any expression is not a literal OR any is reducing -> start with height 0
     let all_literals = phys_expr
         .iter()
         .all(|e| (e.is_literal() || e.is_scalar()) && !is_reducing_expr(e.as_ref()));
+
+    let mut df_height = if all_literals { df.height() } else { 0 };
 
     let verify_scalar = all_literals
         || if !df.get_columns().is_empty() {
@@ -280,8 +302,6 @@ pub(super) fn check_expand_literals(
             true
         };
 
-    // When all expressions are literals, use input df height
-    let mut df_height = if all_literals { df.height() } else { 0 };
     let mut has_empty = false;
     let mut all_equal_len = true;
     {

--- a/crates/polars-mem-engine/src/executors/projection_utils.rs
+++ b/crates/polars-mem-engine/src/executors/projection_utils.rs
@@ -247,6 +247,8 @@ pub(super) fn evaluate_physical_expressions(
 fn is_reducing_expr(phys_expr: &dyn PhysicalExpr) -> bool {
     if let Some(expr) = phys_expr.as_expression() {
         match expr {
+            Expr::Window { .. } => false,
+            Expr::Agg(AggExpr::Implode(_)) => false,
             // Only match pure aggregations that reduce cardinality
             Expr::Agg(agg) => matches!(
                 agg,

--- a/crates/polars-mem-engine/src/executors/projection_utils.rs
+++ b/crates/polars-mem-engine/src/executors/projection_utils.rs
@@ -243,10 +243,10 @@ pub(super) fn evaluate_physical_expressions(
     Ok(selected_columns)
 }
 
-// In cases of aggregate expressions we do not want to expand.
-fn is_aggregate_expr(phys_expr: &dyn PhysicalExpr) -> bool {
+// In cases of aggregate or window expressions we do not want to expand.
+fn is_reducing_expr(phys_expr: &dyn PhysicalExpr) -> bool {
     if let Some(expr) = phys_expr.as_expression() {
-        matches!(expr, Expr::Agg(_))
+        matches!(expr, Expr::Agg(_) | Expr::Window { .. } ) 
     } else {
         false
     }
@@ -268,7 +268,7 @@ pub(super) fn check_expand_literals(
     // In aggregate expressions we can get all literals but not want to expand literals.
     let all_literals = phys_expr
         .iter()
-        .all(|e| (e.is_literal() || e.is_scalar()) && !is_aggregate_expr(e.as_ref()));
+        .all(|e| (e.is_literal() || e.is_scalar()) && !is_reducing_expr(e.as_ref()));
 
     let verify_scalar = all_literals
         || if !df.get_columns().is_empty() {

--- a/crates/polars-mem-engine/src/executors/projection_utils.rs
+++ b/crates/polars-mem-engine/src/executors/projection_utils.rs
@@ -248,7 +248,6 @@ fn is_reducing_expr(phys_expr: &dyn PhysicalExpr) -> bool {
     if let Some(expr) = phys_expr.as_expression() {
         match expr {
             Expr::Window { .. } => false,
-            Expr::Agg(AggExpr::Implode(_)) => false,
             // Only match pure aggregations that reduce cardinality
             Expr::Agg(agg) => matches!(
                 agg,
@@ -264,6 +263,7 @@ fn is_reducing_expr(phys_expr: &dyn PhysicalExpr) -> bool {
                     | AggExpr::Last { .. }
                     | AggExpr::Count { .. }
                     | AggExpr::Quantile { .. }
+                    | AggExpr::Implode { .. }
             ),
             _ => false,
         }


### PR DESCRIPTION
This change is due to issues with the following test. Polars does not naturally expand literals like spark does and we want it to in these cases.

```
test("select literal should return all rows") {
    val schema = StructType(
      Seq(
        StructField("a", IntegerType, nullable = true)
      )
    )

    // making sure we have more than spark.master threads as this can cause the test to return different number of results
    val nums = 1 to 1000
    val data = nums.map(Row(_))

    withSavedParquetTable(schema, data, "tbl") {
      checkSparkAnswerAndOperator(sql("SELECT 1 FROM tbl"))
```

we had a hack in place but it failed in a rand test case and this is better. Relevant PR to be attached.