### PR TITLE
feat: Allow mutable access to the reader field

### DIFF
--- a/crates/polars-arrow/src/io/ipc/read/stream.rs
+++ b/crates/polars-arrow/src/io/ipc/read/stream.rs
@@ -266,6 +266,10 @@ impl<R: Read> StreamReader<R> {
         }
     }
 
+    pub fn reader_mut(&mut self) -> &mut R {
+        &mut self.reader
+    }
+
     /// Return the schema of the stream
     pub fn metadata(&self) -> &StreamMetadata {
         &self.metadata

--- a/crates/polars-io/src/ipc/ipc_stream.rs
+++ b/crates/polars-io/src/ipc/ipc_stream.rs
@@ -79,6 +79,10 @@ pub struct IpcStreamBatchedReader<R: Read> {
 }
 
 impl<R: Read> IpcStreamBatchedReader<R> {
+    pub fn reader_mut(&mut self) -> &mut R {
+        self.reader.reader_mut()
+    }
+
     pub fn read_next_batch(&mut self) -> PolarsResult<Option<DataFrame>> {
         match self.reader.next_record_batch()? {
             None => Ok(None),


### PR DESCRIPTION
Our reader depend's on jniENV, but reader can live more than 1 jni calls. I swap jniENV in runtime, but I need mutable access to the reader for it.
https://github.com/flarioncode/accelerator/pull/239/files#diff-1c5e198ec637996218ec9e3fa879a9dd19840a87e8c55f6149950a328c7b0b7eR80