### PR TITLE
feat(rust): Add support for polars_utils to be available for the floor functions

### DIFF
--- a/crates/polars/src/prelude.rs
+++ b/crates/polars/src/prelude.rs
@@ -8,3 +8,4 @@ pub use polars_lazy::prelude::*;
 pub use polars_ops::prelude::*;
 #[cfg(feature = "temporal")]
 pub use polars_time::prelude::*;
+pub use polars_utils::*;


### PR DESCRIPTION
This PR makes the polars_utils publicly available through polars::prelude.
Used by accelerator PR [here](https://github.com/flarioncode/accelerator/pull/245)