### PR TITLE
fix(rust): Add support for binary blob in lambda

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -259,12 +259,23 @@ impl ChunkFilter<BinaryType> for BinaryChunked {
             return self.filter(&bool_mask);
         }
 
+        // Remove nulls when comparing (< or >) between a variable and a binary blob.
+        let keep_nulls = match lambda {
+            LambdaExpression::GreaterThan(left, right) => {
+                !matches!((left.as_ref(), right.as_ref()), (LambdaExpression::Variable(_), LambdaExpression::BinaryBlob(_)))
+            },
+            LambdaExpression::LessThan(left, right) => {
+                !matches!((left.as_ref(), right.as_ref()), (LambdaExpression::Variable(_), LambdaExpression::BinaryBlob(_)))
+            },
+            _ => true,
+        };
+
         let mask = self.iter().map(|opt_val| match opt_val {
             Some(val) => match lambda.eval_slice(&[val]) {
                 AnyValue::Boolean(b) => b,
                 _ => panic!("Lambda must return boolean values"),
             },
-            None => true,
+            None => keep_nulls,
         });
 
         let bool_mask = BooleanChunked::from_iter_values(self.name().clone(), mask);

--- a/crates/polars-core/src/chunked_array/ops/filter.rs
+++ b/crates/polars-core/src/chunked_array/ops/filter.rs
@@ -261,12 +261,20 @@ impl ChunkFilter<BinaryType> for BinaryChunked {
 
         // Remove nulls when comparing (< or >) between a variable and a binary blob.
         let keep_nulls = match lambda {
-            LambdaExpression::GreaterThan(left, right) => {
-                !matches!((left.as_ref(), right.as_ref()), (LambdaExpression::Variable(_), LambdaExpression::BinaryBlob(_)))
-            },
-            LambdaExpression::LessThan(left, right) => {
-                !matches!((left.as_ref(), right.as_ref()), (LambdaExpression::Variable(_), LambdaExpression::BinaryBlob(_)))
-            },
+            LambdaExpression::GreaterThan(left, right) => !matches!(
+                (left.as_ref(), right.as_ref()),
+                (
+                    LambdaExpression::Variable(_),
+                    LambdaExpression::BinaryBlob(_)
+                )
+            ),
+            LambdaExpression::LessThan(left, right) => !matches!(
+                (left.as_ref(), right.as_ref()),
+                (
+                    LambdaExpression::Variable(_),
+                    LambdaExpression::BinaryBlob(_)
+                )
+            ),
             _ => true,
         };
 


### PR DESCRIPTION
This PR adds supprt for binary blob in lessThan and Greater than in lambda.

Accelerator PR that uses this implementation [here](https://github.com/flarioncode/accelerator/pull/272)