### PR TITLE
feat: Optimize out index series when indices are not used

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -142,6 +142,11 @@ features = [
 # packed_simd_2 = { git = "https://github.com/rust-lang/packed_simd", rev = "e57c7ba11386147e6d2cbad7c88f376aab4bdc86" }
 # simd-json = { git = "https://github.com/ritchie46/simd-json", branch = "alignment" }
 
+# I use this to compile tests otherwise my computer crashes(I think OOM)
+[profile.dev-no-debug]
+inherits = "dev"
+debug = false
+
 [profile.opt-dev]
 inherits = "dev"
 opt-level = 1

--- a/crates/polars-arrow/src/array/primitive/mutable.rs
+++ b/crates/polars-arrow/src/array/primitive/mutable.rs
@@ -282,6 +282,20 @@ impl<T: NativeType> MutablePrimitiveArray<T> {
         }
     }
 
+    /// Truncates the values to the specified len
+    pub fn truncate(&mut self, len: usize) {
+        if len >= self.len() {
+            return;
+        }
+
+        self.values.truncate(len);
+        if let Some(validity) = &mut self.validity {
+            unsafe {
+                validity.set_len(len);
+            }
+        }
+    }
+
     /// Returns the capacity of this [`MutablePrimitiveArray`].
     pub fn capacity(&self) -> usize {
         self.values.capacity()

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -158,6 +158,10 @@ impl LambdaExpression {
         )
     }
 
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     pub fn eval_window<'a>(
         &'a self,
         curr: &AnyValue<'a>,
@@ -312,7 +316,11 @@ impl LambdaExpression {
         }
     }
 
-    pub fn eval(&self, s: &Series, i: &Series, is_root: bool) -> PolarsResult<Series> {
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
+    pub fn eval(&self, s: &Series, i: Option<&Series>, is_root: bool) -> PolarsResult<Series> {
         let repeat_count = if is_root { s.len() } else { 1 }; // Handle broadcast lambdas expressions if root
         match self {
             LambdaExpression::Null => Ok(Series::new_null(PlSmallStr::EMPTY, 1)),
@@ -334,7 +342,7 @@ impl LambdaExpression {
                 Ok(Series::from_iter(iter::repeat_n(v.as_ref(), repeat_count)))
             },
             LambdaExpression::Variable(0) => Ok(s.clone()),
-            LambdaExpression::Variable(1) => Ok(i.clone()),
+            LambdaExpression::Variable(1) => Ok(i.unwrap().clone()),
             LambdaExpression::Variable(_) => {
                 polars_bail!(InvalidOperation: "No 3rd variable exists for eval")
             },
@@ -534,12 +542,9 @@ mod tests {
     #[test]
     fn test_empty_transform() {
         let start_array = Series::from_iter(vec!["key1==value1", "key2===value2"]);
-        let index_series = Series::from_iter(1i32..=start_array.len() as i32);
         let empty_lambda = LambdaExpression::StaticStr("meep".into());
 
-        let res = empty_lambda
-            .eval(&start_array, &index_series, true)
-            .unwrap();
+        let res = empty_lambda.eval(&start_array, None, true).unwrap();
         assert_eq!(res.len(), 2);
 
         assert_eq!(res.str().unwrap().get(0).unwrap(), "meep");
@@ -549,12 +554,9 @@ mod tests {
     #[test]
     fn test_lambda_length() {
         let start_array = Series::from_iter(vec!["key1==value1", "key2===value2"]);
-        let index_series = Series::from_iter(1i32..=start_array.len() as i32);
         let length_lambda = LambdaExpression::Length(Box::new(LambdaExpression::Variable(0)));
 
-        let res = length_lambda
-            .eval(&start_array, &index_series, true)
-            .unwrap();
+        let res = length_lambda.eval(&start_array, None, true).unwrap();
         unsafe {
             assert_eq!(res.i32().unwrap().value_unchecked(0), 12);
             assert_eq!(res.i32().unwrap().value_unchecked(1), 13);
@@ -564,16 +566,13 @@ mod tests {
     #[test]
     fn test_lambda_substring() {
         let start_array = Series::from_iter(vec!["key1==value1", "key2===value2"]);
-        let index_series = Series::from_iter(1i32..=start_array.len() as i32);
         let substring_lambda = LambdaExpression::Substring(
             Box::new(LambdaExpression::Variable(0)),
             Box::new(LambdaExpression::Int32(4)),
             Box::new(LambdaExpression::Int32(2)),
         );
 
-        let res = substring_lambda
-            .eval(&start_array, &index_series, true)
-            .unwrap();
+        let res = substring_lambda.eval(&start_array, None, true).unwrap();
         // Substring should start at the index of the element in the array + 2
         unsafe {
             assert_eq!(res.str().unwrap().value_unchecked(0), "1=");
@@ -595,7 +594,7 @@ mod tests {
         );
 
         let res = substring_lambda
-            .eval(&start_array, &index_series, true)
+            .eval(&start_array, Some(&index_series), true)
             .unwrap();
         unsafe {
             assert_eq!(res.str().unwrap().value_unchecked(0), "y1");
@@ -611,7 +610,6 @@ mod tests {
             "key2===u",
             "key3==value3whichisverylong",
         ]);
-        let index_series = Series::from_iter(1i32..=start_array.len() as i32);
         let casewhen_lambda = LambdaExpression::CaseWhen(
             vec![(
                 LambdaExpression::GreaterThan(
@@ -625,9 +623,7 @@ mod tests {
             Box::new(LambdaExpression::StaticStr("nope".into())),
         );
 
-        let res = casewhen_lambda
-            .eval(&start_array, &index_series, true)
-            .unwrap();
+        let res = casewhen_lambda.eval(&start_array, None, true).unwrap();
         unsafe {
             assert_eq!(res.str().unwrap().value_unchecked(0), "key1==value1");
             assert_eq!(res.str().unwrap().value_unchecked(1), "nope");

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -1,6 +1,5 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
-use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::Add;
 use std::{iter, mem};
@@ -144,43 +143,41 @@ impl Hash for LambdaExpression {
     }
 }
 
-impl Display for LambdaExpression {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+impl LambdaExpression {
+    fn fmt_str(&self) -> &'static str {
         match self {
-            LambdaExpression::Null => write!(f, "literal(null)"),
-            LambdaExpression::Boolean(_) => write!(f, "literal(boolean)"),
+            LambdaExpression::Null => "literal(null)",
+            LambdaExpression::Boolean(_) => "literal(boolean)",
             #[cfg(feature = "dtype-i8")]
-            LambdaExpression::Int8(_) => write!(f, "literal(int8)"),
+            LambdaExpression::Int8(_) => "literal(int8)",
             #[cfg(feature = "dtype-i16")]
-            LambdaExpression::Int16(_) => write!(f, "literal(int16)"),
-            LambdaExpression::Int32(_) => write!(f, "literal(int32)"),
-            LambdaExpression::Int64(_) => write!(f, "literal(int64)"),
-            LambdaExpression::Float32(_) => write!(f, "literal(float32)"),
-            LambdaExpression::Float64(_) => write!(f, "literal(float64)"),
-            LambdaExpression::BinaryBlob(_) => write!(f, "literal(binary)"),
-            LambdaExpression::StaticStr(_) => write!(f, "literal(string)"),
-            LambdaExpression::Variable(v) => write!(f, "variable({})", v),
-            LambdaExpression::GreaterThan(_, _) => write!(f, "greater_than"),
-            LambdaExpression::GreaterThanOrEqual(_, _) => write!(f, "greater_than_or_equal"),
-            LambdaExpression::LessThan(_, _) => write!(f, "less_than"),
-            LambdaExpression::LessThanOrEqual(_, _) => write!(f, "less_than_or_equal"),
+            LambdaExpression::Int16(_) => "literal(int16)",
+            LambdaExpression::Int32(_) => "literal(int32)",
+            LambdaExpression::Int64(_) => "literal(int64)",
+            LambdaExpression::Float32(_) => "literal(float32)",
+            LambdaExpression::Float64(_) => "literal(float64)",
+            LambdaExpression::BinaryBlob(_) => "literal(binary)",
+            LambdaExpression::StaticStr(_) => "literal(string)",
+            LambdaExpression::Variable(_) => "variable({})",
+            LambdaExpression::GreaterThan(_, _) => "greater_than",
+            LambdaExpression::GreaterThanOrEqual(_, _) => "greater_than_or_equal",
+            LambdaExpression::LessThan(_, _) => "less_than",
+            LambdaExpression::LessThanOrEqual(_, _) => "less_than_or_equal",
             #[cfg(feature = "zip_with")]
-            LambdaExpression::IfThenElse(_, _, _) => write!(f, "if_then_else"),
-            LambdaExpression::Length(_) => write!(f, "length"),
+            LambdaExpression::IfThenElse(_, _, _) => "if_then_else",
+            LambdaExpression::Length(_) => "length",
             #[cfg(feature = "zip_with")]
-            LambdaExpression::CaseWhen(_, _) => write!(f, "case_when"),
-            LambdaExpression::Substring(_, _, _) => write!(f, "substring"),
-            LambdaExpression::Instr(_, _) => write!(f, "instr"),
-            LambdaExpression::Add(_, _) => write!(f, "add"),
-            LambdaExpression::IsNull(_) => write!(f, "is_null"),
-            LambdaExpression::IsNotNull(_) => write!(f, "is_not_null"),
-            LambdaExpression::EqualNullSafe(_, _) => write!(f, "equal_null_safe"),
-            LambdaExpression::Cast(_, _) => write!(f, "cast"),
+            LambdaExpression::CaseWhen(_, _) => "case_when",
+            LambdaExpression::Substring(_, _, _) => "substring",
+            LambdaExpression::Instr(_, _) => "instr",
+            LambdaExpression::Add(_, _) => "add",
+            LambdaExpression::IsNull(_) => "is_null",
+            LambdaExpression::IsNotNull(_) => "is_not_null",
+            LambdaExpression::EqualNullSafe(_, _) => "equal_null_safe",
+            LambdaExpression::Cast(_, _) => "cast",
         }
     }
-}
 
-impl LambdaExpression {
     pub fn is_literal(&self) -> bool {
         matches!(
             self,
@@ -203,7 +200,7 @@ impl LambdaExpression {
         #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
         tracy_gizmos::zone!(span, "evaluate");
         #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
-        span.text(self.to_string());
+        span.text(self.fmt_str());
 
         match self {
             LambdaExpression::Null => Ok(AnyValue::Null),
@@ -358,7 +355,7 @@ impl LambdaExpression {
         #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
         tracy_gizmos::zone!(span, "evaluate");
         #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
-        span.text(self.to_string());
+        span.text(self.fmt_str());
 
         match self {
             LambdaExpression::Null => Ok(Series::new_null(PlSmallStr::EMPTY, 1)),
@@ -563,202 +560,5 @@ impl LambdaExpression {
             LambdaExpression::EqualNullSafe(_, _) => DataType::Boolean,
             LambdaExpression::Cast(_, data_type) => data_type.clone(),
         })
-    }
-}
-
-// Was using these to debug but I see no harm in having more unit tests, in fact we should probably have more here
-#[cfg(test)]
-mod tests {
-    use crate::prelude::{AnyValue, LambdaExpression, Series};
-
-    #[test]
-    fn test_empty_transform() {
-        let start_array = Series::from_iter(vec!["key1==value1", "key2===value2"]);
-        let empty_lambda = LambdaExpression::StaticStr("meep".into());
-
-        let res = empty_lambda.eval(&start_array, None).unwrap();
-        assert_eq!(res.len(), 2);
-
-        assert_eq!(res.str().unwrap().get(0).unwrap(), "meep");
-        assert_eq!(res.str().unwrap().get(1).unwrap(), "meep");
-    }
-
-    #[test]
-    fn test_lambda_length() {
-        let start_array = Series::from_iter(vec!["key1==value1", "key2===value2"]);
-        let length_lambda = LambdaExpression::Length(Box::new(LambdaExpression::Variable(0)));
-
-        let res = length_lambda.eval(&start_array, None).unwrap();
-        unsafe {
-            assert_eq!(res.i32().unwrap().value_unchecked(0), 12);
-            assert_eq!(res.i32().unwrap().value_unchecked(1), 13);
-        }
-    }
-
-    #[test]
-    fn test_lambda_substring() {
-        let start_array = Series::from_iter(vec!["key1==value1", "key2===value2"]);
-        let substring_lambda = LambdaExpression::Substring(
-            Box::new(LambdaExpression::Variable(0)),
-            Box::new(LambdaExpression::Int32(4)),
-            Box::new(LambdaExpression::Int32(2)),
-        );
-
-        let res = substring_lambda.eval(&start_array, None).unwrap();
-        // Substring should start at the index of the element in the array + 2
-        unsafe {
-            assert_eq!(res.str().unwrap().value_unchecked(0), "1=");
-            assert_eq!(res.str().unwrap().value_unchecked(1), "2=");
-        }
-    }
-
-    #[test]
-    fn test_lambda_with_index() {
-        let start_array = Series::from_iter(vec!["key1==value1", "key2===value2"]);
-        let index_series = Series::from_iter(1i32..=start_array.len() as i32);
-        let substring_lambda = LambdaExpression::Substring(
-            Box::new(LambdaExpression::Variable(0)),
-            Box::new(LambdaExpression::Add(
-                Box::new(LambdaExpression::Variable(1)),
-                Box::new(LambdaExpression::Int32(2)),
-            )),
-            Box::new(LambdaExpression::Int32(2)),
-        );
-
-        let res = substring_lambda
-            .eval(&start_array, Some(&index_series))
-            .unwrap();
-        unsafe {
-            assert_eq!(res.str().unwrap().value_unchecked(0), "y1");
-            assert_eq!(res.str().unwrap().value_unchecked(1), "2=");
-        }
-    }
-
-    #[cfg(feature = "zip_with")]
-    #[test]
-    fn test_lambda_casewhen() {
-        let start_array = Series::from_iter(vec![
-            "key1==value1",
-            "key2===u",
-            "key3==value3whichisverylong",
-        ]);
-        let casewhen_lambda = LambdaExpression::CaseWhen(
-            vec![(
-                LambdaExpression::GreaterThan(
-                    Box::new(LambdaExpression::Length(Box::new(
-                        LambdaExpression::Variable(0),
-                    ))),
-                    Box::new(LambdaExpression::Int32(10)),
-                ),
-                LambdaExpression::Variable(0),
-            )],
-            Box::new(LambdaExpression::StaticStr("nope".into())),
-        );
-
-        let res = casewhen_lambda.eval(&start_array, None).unwrap();
-        unsafe {
-            assert_eq!(res.str().unwrap().value_unchecked(0), "key1==value1");
-            assert_eq!(res.str().unwrap().value_unchecked(1), "nope");
-            assert_eq!(
-                res.str().unwrap().value_unchecked(2),
-                "key3==value3whichisverylong"
-            );
-        }
-    }
-
-    #[cfg(feature = "zip_with")]
-    #[test]
-    fn test_array_sort() {
-        // let start_array = Series::from_iter(vec![0i32, 0, 0, 0, 0]);
-        let start_array = Series::from_iter(vec![
-            Some(1i32),
-            None,
-            Some(2),
-            Some(3),
-            None,
-            Some(4),
-            Some(5),
-        ]);
-        // CASE
-        // WHEN
-        //     isnull(lambda x_8#28858)
-        // THEN
-        //     CASE
-        //     WHEN
-        //         isnull(lambda y_9#28859)
-        //     THEN
-        //         0
-        //     ELSE
-        //         1
-        //     END
-        // WHEN
-        //     isnull(lambda y_9#28859)
-        // THEN
-        //     -1
-        // WHEN
-        //     (lambda x_8#28858 > lambda y_9#28859)
-        // THEN
-        //     1
-        // WHEN
-        //     (lambda x_8#28858 < lambda y_9#28859)
-        // THEN
-        //     -1
-        // ELSE
-        //     0
-        // END
-        let ascending_lambda = LambdaExpression::CaseWhen(
-            vec![
-                (
-                    LambdaExpression::IsNull(LambdaExpression::Variable(0).into()),
-                    LambdaExpression::CaseWhen(
-                        vec![(
-                            LambdaExpression::IsNull(LambdaExpression::Variable(1).into()),
-                            LambdaExpression::Int32(0),
-                        )],
-                        LambdaExpression::Int32(1).into(),
-                    ),
-                ),
-                (
-                    LambdaExpression::IsNull(LambdaExpression::Variable(1).into()),
-                    LambdaExpression::Int32(-1),
-                ),
-                (
-                    LambdaExpression::GreaterThan(
-                        LambdaExpression::Variable(0).into(),
-                        LambdaExpression::Variable(1).into(),
-                    ),
-                    LambdaExpression::Int32(1),
-                ),
-                (
-                    LambdaExpression::LessThan(
-                        LambdaExpression::Variable(0).into(),
-                        LambdaExpression::Variable(1).into(),
-                    ),
-                    LambdaExpression::Int32(-1),
-                ),
-            ],
-            LambdaExpression::Int32(0).into(),
-        );
-
-        let mut vals = start_array.iter().collect::<Vec<_>>();
-        vals.sort_by(|curr, next| {
-            ascending_lambda
-                .eval_window(curr, next)
-                .unwrap()
-                .try_into()
-                .unwrap()
-        });
-        assert_eq!(
-            vals,
-            vec![
-                AnyValue::Int32(1),
-                AnyValue::Int32(2),
-                AnyValue::Int32(3),
-                AnyValue::Int32(4),
-                AnyValue::Int32(5),
-                AnyValue::Null,
-                AnyValue::Null
-            ]
-        );
     }
 }

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -144,6 +144,7 @@ impl Hash for LambdaExpression {
 }
 
 impl LambdaExpression {
+    #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
     fn fmt_str(&self) -> &'static str {
         match self {
             LambdaExpression::Null => "literal(null)",

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -1,5 +1,6 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
+use std::fmt::{Display, Formatter};
 use std::hash::{Hash, Hasher};
 use std::ops::Add;
 use std::{iter, mem};
@@ -143,6 +144,42 @@ impl Hash for LambdaExpression {
     }
 }
 
+impl Display for LambdaExpression {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LambdaExpression::Null => write!(f, "literal(null)"),
+            LambdaExpression::Boolean(_) => write!(f, "literal(boolean)"),
+            #[cfg(feature = "dtype-i8")]
+            LambdaExpression::Int8(_) => write!(f, "literal(int8)"),
+            #[cfg(feature = "dtype-i16")]
+            LambdaExpression::Int16(_) => write!(f, "literal(int16)"),
+            LambdaExpression::Int32(_) => write!(f, "literal(int32)"),
+            LambdaExpression::Int64(_) => write!(f, "literal(int64)"),
+            LambdaExpression::Float32(_) => write!(f, "literal(float32)"),
+            LambdaExpression::Float64(_) => write!(f, "literal(float64)"),
+            LambdaExpression::BinaryBlob(_) => write!(f, "literal(binary)"),
+            LambdaExpression::StaticStr(_) => write!(f, "literal(string)"),
+            LambdaExpression::Variable(v) => write!(f, "variable({})", v),
+            LambdaExpression::GreaterThan(_, _) => write!(f, "greater_than"),
+            LambdaExpression::GreaterThanOrEqual(_, _) => write!(f, "greater_than_or_equal"),
+            LambdaExpression::LessThan(_, _) => write!(f, "less_than"),
+            LambdaExpression::LessThanOrEqual(_, _) => write!(f, "less_than_or_equal"),
+            #[cfg(feature = "zip_with")]
+            LambdaExpression::IfThenElse(_, _, _) => write!(f, "if_then_else"),
+            LambdaExpression::Length(_) => write!(f, "length"),
+            #[cfg(feature = "zip_with")]
+            LambdaExpression::CaseWhen(_, _) => write!(f, "case_when"),
+            LambdaExpression::Substring(_, _, _) => write!(f, "substring"),
+            LambdaExpression::Instr(_, _) => write!(f, "instr"),
+            LambdaExpression::Add(_, _) => write!(f, "add"),
+            LambdaExpression::IsNull(_) => write!(f, "is_null"),
+            LambdaExpression::IsNotNull(_) => write!(f, "is_not_null"),
+            LambdaExpression::EqualNullSafe(_, _) => write!(f, "equal_null_safe"),
+            LambdaExpression::Cast(_, _) => write!(f, "cast"),
+        }
+    }
+}
+
 impl LambdaExpression {
     pub fn is_literal(&self) -> bool {
         matches!(
@@ -158,15 +195,16 @@ impl LambdaExpression {
         )
     }
 
-    #[cfg_attr(
-        all(feature = "tracy", not(feature = "tracy-no-instrument")),
-        tracy_gizmos::instrument
-    )]
     pub fn eval_window<'a>(
         &'a self,
         curr: &AnyValue<'a>,
         next: &AnyValue<'a>,
     ) -> PolarsResult<AnyValue<'a>> {
+        #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
+        tracy_gizmos::zone!(span, "evaluate");
+        #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
+        span.text(self.to_string());
+
         match self {
             LambdaExpression::Null => Ok(AnyValue::Null),
             LambdaExpression::Boolean(v) => Ok(AnyValue::Boolean(*v)),
@@ -316,61 +354,57 @@ impl LambdaExpression {
         }
     }
 
-    #[cfg_attr(
-        all(feature = "tracy", not(feature = "tracy-no-instrument")),
-        tracy_gizmos::instrument
-    )]
-    pub fn eval(&self, s: &Series, i: Option<&Series>, is_root: bool) -> PolarsResult<Series> {
-        let repeat_count = if is_root { s.len() } else { 1 }; // Handle broadcast lambdas expressions if root
+    pub fn eval(&self, s: &Series, i: Option<&Series>) -> PolarsResult<Series> {
+        #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
+        tracy_gizmos::zone!(span, "evaluate");
+        #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
+        span.text(self.to_string());
+
         match self {
             LambdaExpression::Null => Ok(Series::new_null(PlSmallStr::EMPTY, 1)),
-            LambdaExpression::Boolean(v) => Ok(Series::from_iter(iter::repeat_n(v, repeat_count))),
+            LambdaExpression::Boolean(v) => Ok(Series::from_iter(iter::once(v))),
             #[cfg(feature = "dtype-i8")]
-            LambdaExpression::Int8(v) => Ok(Series::from_iter(iter::repeat_n(v, repeat_count))),
+            LambdaExpression::Int8(v) => Ok(Series::from_iter(iter::once(v))),
             #[cfg(feature = "dtype-i16")]
-            LambdaExpression::Int16(v) => Ok(Series::from_iter(iter::repeat_n(v, repeat_count))),
-            LambdaExpression::Int32(v) => Ok(Series::from_iter(iter::repeat_n(v, repeat_count))),
-            LambdaExpression::Int64(v) => Ok(Series::from_iter(iter::repeat_n(v, repeat_count))),
-            LambdaExpression::Float32(v) => Ok(Series::from_iter(iter::repeat_n(v, repeat_count))),
-            LambdaExpression::Float64(v) => Ok(Series::from_iter(iter::repeat_n(v, repeat_count))),
-            LambdaExpression::BinaryBlob(v) => Ok(BinaryChunked::from_iter(iter::repeat_n(
-                v.as_slice(),
-                repeat_count,
-            ))
-            .into_series()),
-            LambdaExpression::StaticStr(v) => {
-                Ok(Series::from_iter(iter::repeat_n(v.as_ref(), repeat_count)))
+            LambdaExpression::Int16(v) => Ok(Series::from_iter(iter::once(v))),
+            LambdaExpression::Int32(v) => Ok(Series::from_iter(iter::once(v))),
+            LambdaExpression::Int64(v) => Ok(Series::from_iter(iter::once(v))),
+            LambdaExpression::Float32(v) => Ok(Series::from_iter(iter::once(v))),
+            LambdaExpression::Float64(v) => Ok(Series::from_iter(iter::once(v))),
+            LambdaExpression::BinaryBlob(v) => {
+                Ok(BinaryChunked::from_iter(iter::once(v.as_slice())).into_series())
             },
+            LambdaExpression::StaticStr(v) => Ok(Series::from_iter(iter::once(v.as_ref()))),
             LambdaExpression::Variable(0) => Ok(s.clone()),
-            LambdaExpression::Variable(1) => Ok(i.unwrap().clone()),
+            LambdaExpression::Variable(1) => Ok(i.unwrap().clone()), // Will never get called if there are not indices
             LambdaExpression::Variable(_) => {
                 polars_bail!(InvalidOperation: "No 3rd variable exists for eval")
             },
             LambdaExpression::GreaterThan(left, right) => {
-                let left = left.eval(s, i, false)?;
-                let right = right.eval(s, i, false)?;
+                let left = left.eval(s, i)?;
+                let right = right.eval(s, i)?;
                 Ok(left.gt(&right)?.into_series())
             },
             LambdaExpression::GreaterThanOrEqual(left, right) => {
-                let left = left.eval(s, i, false)?;
-                let right = right.eval(s, i, false)?;
+                let left = left.eval(s, i)?;
+                let right = right.eval(s, i)?;
                 Ok(left.gt_eq(&right)?.into_series())
             },
             LambdaExpression::LessThan(left, right) => {
-                let left = left.eval(s, i, false)?;
-                let right = right.eval(s, i, false)?;
+                let left = left.eval(s, i)?;
+                let right = right.eval(s, i)?;
                 Ok(left.lt(&right)?.into_series())
             },
             LambdaExpression::LessThanOrEqual(left, right) => {
-                let left = left.eval(s, i, false)?;
-                let right = right.eval(s, i, false)?;
+                let left = left.eval(s, i)?;
+                let right = right.eval(s, i)?;
                 Ok(left.lt_eq(&right)?.into_series())
             },
             #[cfg(feature = "zip_with")]
             LambdaExpression::IfThenElse(pred, value, otherwise) => {
-                let pred = pred.eval(s, i, false)?;
-                let value = value.eval(s, i, false)?;
-                let otherwise = otherwise.eval(s, i, false)?;
+                let pred = pred.eval(s, i)?;
+                let value = value.eval(s, i)?;
+                let otherwise = otherwise.eval(s, i)?;
 
                 // I think this is the only place where its valid to use AnyValues, since both series can be absolutely anything
                 value
@@ -378,7 +412,7 @@ impl LambdaExpression {
                     .map(IntoSeries::into_series)
             },
             LambdaExpression::Length(child) => {
-                let s = child.eval(s, i, false)?;
+                let s = child.eval(s, i)?;
                 Ok(match s.dtype() {
                     DataType::Null => Series::new_null(PlSmallStr::EMPTY, s.len()),
                     DataType::Binary => Series::from_iter(
@@ -411,16 +445,14 @@ impl LambdaExpression {
             LambdaExpression::CaseWhen(branches, otherwise) => {
                 let predicates: Vec<Series> = branches
                     .iter()
-                    .map(|(pred, _)| pred.eval(s, i, false))
+                    .map(|(pred, _)| pred.eval(s, i))
                     .collect::<PolarsResult<_>>()?;
                 let branches: Vec<(&BooleanChunked, Series)> = predicates
                     .iter()
                     .zip(branches)
-                    .map(|(predicates, (_, thens))| {
-                        Ok((predicates.bool()?, thens.eval(s, i, false)?))
-                    })
+                    .map(|(predicates, (_, thens))| Ok((predicates.bool()?, thens.eval(s, i)?)))
                     .collect::<PolarsResult<_>>()?;
-                let otherwise: Series = otherwise.eval(s, i, false)?;
+                let otherwise: Series = otherwise.eval(s, i)?;
 
                 // Start with all false mask of appropriate length
                 let mut final_mask =
@@ -445,38 +477,38 @@ impl LambdaExpression {
                 Ok(result)
             },
             LambdaExpression::Substring(child, start, length) => {
-                let child = child.eval(s, i, false)?;
-                let start = start.eval(s, i, false)?;
-                let length = length.eval(s, i, false)?;
+                let child = child.eval(s, i)?;
+                let start = start.eval(s, i)?;
+                let length = length.eval(s, i)?;
 
                 flarion_slice_helper(child.str()?, &start, &length)
             },
             LambdaExpression::Instr(left, right) => {
-                let left = left.eval(s, i, false)?;
-                let right = right.eval(s, i, false)?;
+                let left = left.eval(s, i)?;
+                let right = right.eval(s, i)?;
 
                 flarion_instr_helper(left.str()?, &right)
             },
             LambdaExpression::Add(left, right) => {
-                let left = left.eval(s, i, false)?;
-                let right = right.eval(s, i, false)?;
+                let left = left.eval(s, i)?;
+                let right = right.eval(s, i)?;
                 left.add(right)
             },
             LambdaExpression::IsNull(child) => {
-                let child = child.eval(s, i, false)?;
+                let child = child.eval(s, i)?;
                 Ok(child.is_null().into_series())
             },
             LambdaExpression::IsNotNull(child) => {
-                let child = child.eval(s, i, false)?;
+                let child = child.eval(s, i)?;
                 Ok(child.is_not_null().into_series())
             },
             LambdaExpression::EqualNullSafe(left, right) => {
-                let left = left.eval(s, i, false)?;
-                let right = right.eval(s, i, false)?;
+                let left = left.eval(s, i)?;
+                let right = right.eval(s, i)?;
                 left.equal_missing(&right).map(IntoSeries::into_series)
             },
             LambdaExpression::Cast(child, dtype) => {
-                let s = child.eval(s, i, false)?;
+                let s = child.eval(s, i)?;
                 s.cast_with_options(dtype, CastOptions::Overflowing)
             },
         }
@@ -544,7 +576,7 @@ mod tests {
         let start_array = Series::from_iter(vec!["key1==value1", "key2===value2"]);
         let empty_lambda = LambdaExpression::StaticStr("meep".into());
 
-        let res = empty_lambda.eval(&start_array, None, true).unwrap();
+        let res = empty_lambda.eval(&start_array, None).unwrap();
         assert_eq!(res.len(), 2);
 
         assert_eq!(res.str().unwrap().get(0).unwrap(), "meep");
@@ -556,7 +588,7 @@ mod tests {
         let start_array = Series::from_iter(vec!["key1==value1", "key2===value2"]);
         let length_lambda = LambdaExpression::Length(Box::new(LambdaExpression::Variable(0)));
 
-        let res = length_lambda.eval(&start_array, None, true).unwrap();
+        let res = length_lambda.eval(&start_array, None).unwrap();
         unsafe {
             assert_eq!(res.i32().unwrap().value_unchecked(0), 12);
             assert_eq!(res.i32().unwrap().value_unchecked(1), 13);
@@ -572,7 +604,7 @@ mod tests {
             Box::new(LambdaExpression::Int32(2)),
         );
 
-        let res = substring_lambda.eval(&start_array, None, true).unwrap();
+        let res = substring_lambda.eval(&start_array, None).unwrap();
         // Substring should start at the index of the element in the array + 2
         unsafe {
             assert_eq!(res.str().unwrap().value_unchecked(0), "1=");
@@ -594,7 +626,7 @@ mod tests {
         );
 
         let res = substring_lambda
-            .eval(&start_array, Some(&index_series), true)
+            .eval(&start_array, Some(&index_series))
             .unwrap();
         unsafe {
             assert_eq!(res.str().unwrap().value_unchecked(0), "y1");
@@ -623,7 +655,7 @@ mod tests {
             Box::new(LambdaExpression::StaticStr("nope".into())),
         );
 
-        let res = casewhen_lambda.eval(&start_array, None, true).unwrap();
+        let res = casewhen_lambda.eval(&start_array, None).unwrap();
         unsafe {
             assert_eq!(res.str().unwrap().value_unchecked(0), "key1==value1");
             assert_eq!(res.str().unwrap().value_unchecked(1), "nope");

--- a/crates/polars-expr/src/expressions/aggregation.rs
+++ b/crates/polars-expr/src/expressions/aggregation.rs
@@ -50,6 +50,10 @@ impl PhysicalExpr for AggregationExpr {
         None
     }
 
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
         let s = self.input.evaluate(df, state)?;
 
@@ -177,6 +181,7 @@ impl PhysicalExpr for AggregationExpr {
             GroupByMethod::Quantile(_, _) => unimplemented!(),
         }
     }
+
     #[allow(clippy::ptr_arg)]
     #[cfg_attr(
         all(feature = "tracy", not(feature = "tracy-no-instrument")),
@@ -713,6 +718,10 @@ impl PhysicalExpr for AggQuantileExpr {
         None
     }
 
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
         let input = self.input.evaluate(df, state)?;
         let quantile = self.get_quantile(df, state)?;
@@ -720,6 +729,7 @@ impl PhysicalExpr for AggQuantileExpr {
             .quantile_reduce(quantile, self.interpol)
             .map(|sc| sc.into_series(input.name().clone()))
     }
+
     #[allow(clippy::ptr_arg)]
     #[cfg_attr(
         all(feature = "tracy", not(feature = "tracy-no-instrument")),

--- a/crates/polars-expr/src/expressions/apply.rs
+++ b/crates/polars-expr/src/expressions/apply.rs
@@ -27,6 +27,8 @@ pub struct ApplyExpr {
     check_lengths: bool,
     allow_group_aware: bool,
     output_dtype: Option<DataType>,
+    #[allow(dead_code)]
+    fmt_str: &'static str, // Only used in tracy
 }
 
 impl ApplyExpr {
@@ -62,6 +64,7 @@ impl ApplyExpr {
             check_lengths: options.check_lengths(),
             allow_group_aware: options.flags.contains(FunctionFlags::ALLOW_GROUP_AWARE),
             output_dtype,
+            fmt_str: options.fmt_str,
         }
     }
 
@@ -85,6 +88,7 @@ impl ApplyExpr {
             check_lengths: true,
             allow_group_aware: true,
             output_dtype: None,
+            fmt_str: "apply",
         }
     }
 
@@ -320,6 +324,11 @@ impl PhysicalExpr for ApplyExpr {
     }
 
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
+        #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
+        tracy_gizmos::zone!(span, "evaluate");
+        #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
+        span.text(self.fmt_str);
+
         let f = |e: &Arc<dyn PhysicalExpr>| e.evaluate(df, state);
         let mut inputs = if self.allow_threading && self.inputs.len() > 1 {
             POOL.install(|| {
@@ -341,16 +350,17 @@ impl PhysicalExpr for ApplyExpr {
     }
 
     #[allow(clippy::ptr_arg)]
-    #[cfg_attr(
-        all(feature = "tracy", not(feature = "tracy-no-instrument")),
-        tracy_gizmos::instrument
-    )]
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,
         groups: &'a GroupsProxy,
         state: &ExecutionState,
     ) -> PolarsResult<AggregationContext<'a>> {
+        #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
+        tracy_gizmos::zone!(span, "evaluate_on_groups");
+        #[cfg(all(feature = "tracy", not(feature = "tracy-no-instrument")))]
+        span.text(self.fmt_str);
+
         polars_ensure!(
             self.allow_group_aware,
             expr = self.expr,

--- a/crates/polars-expr/src/expressions/column.rs
+++ b/crates/polars-expr/src/expressions/column.rs
@@ -133,10 +133,7 @@ impl PhysicalExpr for ColumnExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
-    #[cfg_attr(
-        all(feature = "tracy", not(feature = "tracy-no-instrument")),
-        tracy_gizmos::instrument
-    )]
+
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
         let out = match &self.schema {
             None => self.process_by_linear_search(df, state, false),

--- a/crates/polars-expr/src/expressions/count.rs
+++ b/crates/polars-expr/src/expressions/count.rs
@@ -21,6 +21,10 @@ impl PhysicalExpr for CountExpr {
         Some(&self.expr)
     }
 
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn evaluate(&self, df: &DataFrame, _state: &ExecutionState) -> PolarsResult<Series> {
         Ok(Series::new(
             PlSmallStr::from_static("len"),
@@ -28,6 +32,10 @@ impl PhysicalExpr for CountExpr {
         ))
     }
 
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn evaluate_on_groups<'a>(
         &self,
         _df: &DataFrame,

--- a/crates/polars-expr/src/expressions/filter.rs
+++ b/crates/polars-expr/src/expressions/filter.rs
@@ -24,6 +24,7 @@ impl PhysicalExpr for FilterExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
+
     #[cfg_attr(
         all(feature = "tracy", not(feature = "tracy-no-instrument")),
         tracy_gizmos::instrument
@@ -38,6 +39,10 @@ impl PhysicalExpr for FilterExpr {
         series.filter(predicate.bool()?)
     }
 
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,

--- a/crates/polars-expr/src/expressions/flarion/normalize_nan_and_zero.rs
+++ b/crates/polars-expr/src/expressions/flarion/normalize_nan_and_zero.rs
@@ -52,6 +52,10 @@ impl PhysicalExpr for FlarionNormalizeNanAndZeroExpr {
         Some(&self.expr)
     }
 
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
         let s_f = || self.input.evaluate(df, state);
 

--- a/crates/polars-expr/src/expressions/gather.rs
+++ b/crates/polars-expr/src/expressions/gather.rs
@@ -19,6 +19,7 @@ impl PhysicalExpr for GatherExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
+
     #[cfg_attr(
         all(feature = "tracy", not(feature = "tracy-no-instrument")),
         tracy_gizmos::instrument
@@ -28,11 +29,11 @@ impl PhysicalExpr for GatherExpr {
         self.finish(df, state, series)
     }
 
-    #[allow(clippy::ptr_arg)]
     #[cfg_attr(
         all(feature = "tracy", not(feature = "tracy-no-instrument")),
         tracy_gizmos::instrument
     )]
+    #[allow(clippy::ptr_arg)]
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,

--- a/crates/polars-expr/src/expressions/literal.rs
+++ b/crates/polars-expr/src/expressions/literal.rs
@@ -20,6 +20,11 @@ impl PhysicalExpr for LiteralExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.1)
     }
+
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn evaluate(&self, _df: &DataFrame, _state: &ExecutionState) -> PolarsResult<Series> {
         use LiteralValue::*;
         let s = match &self.0 {
@@ -106,6 +111,10 @@ impl PhysicalExpr for LiteralExpr {
         Ok(s)
     }
 
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     #[allow(clippy::ptr_arg)]
     fn evaluate_on_groups<'a>(
         &self,

--- a/crates/polars-expr/src/expressions/rolling.rs
+++ b/crates/polars-expr/src/expressions/rolling.rs
@@ -19,6 +19,10 @@ pub(crate) struct RollingExpr {
 }
 
 impl PhysicalExpr for RollingExpr {
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
         let groups_key = format!("{:?}", &self.options);
 

--- a/crates/polars-expr/src/expressions/slice.rs
+++ b/crates/polars-expr/src/expressions/slice.rs
@@ -82,6 +82,10 @@ impl PhysicalExpr for SliceExpr {
         Some(&self.expr)
     }
 
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
         let results = POOL.install(|| {
             [&self.offset, &self.length, &self.input]

--- a/crates/polars-expr/src/expressions/sort.rs
+++ b/crates/polars-expr/src/expressions/sort.rs
@@ -47,6 +47,7 @@ impl PhysicalExpr for SortExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
+
     #[cfg_attr(
         all(feature = "tracy", not(feature = "tracy-no-instrument")),
         tracy_gizmos::instrument
@@ -56,11 +57,11 @@ impl PhysicalExpr for SortExpr {
         series.sort_with(self.options)
     }
 
-    #[allow(clippy::ptr_arg)]
     #[cfg_attr(
         all(feature = "tracy", not(feature = "tracy-no-instrument")),
         tracy_gizmos::instrument
     )]
+    #[allow(clippy::ptr_arg)]
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,

--- a/crates/polars-expr/src/expressions/sortby.rs
+++ b/crates/polars-expr/src/expressions/sortby.rs
@@ -191,6 +191,7 @@ impl PhysicalExpr for SortByExpr {
     fn as_expression(&self) -> Option<&Expr> {
         Some(&self.expr)
     }
+
     #[cfg_attr(
         all(feature = "tracy", not(feature = "tracy-no-instrument")),
         tracy_gizmos::instrument
@@ -251,11 +252,11 @@ impl PhysicalExpr for SortByExpr {
         unsafe { Ok(series.take_unchecked(&sorted_idx)) }
     }
 
-    #[allow(clippy::ptr_arg)]
     #[cfg_attr(
         all(feature = "tracy", not(feature = "tracy-no-instrument")),
         tracy_gizmos::instrument
     )]
+    #[allow(clippy::ptr_arg)]
     fn evaluate_on_groups<'a>(
         &self,
         df: &DataFrame,

--- a/crates/polars-expr/src/expressions/window.rs
+++ b/crates/polars-expr/src/expressions/window.rs
@@ -377,6 +377,10 @@ impl PhysicalExpr for WindowExpr {
 
     // This first cached the group_by and the join tuples, but rayon under a mutex leads to deadlocks:
     // https://github.com/rayon-rs/rayon/issues/592
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn evaluate(&self, df: &DataFrame, state: &ExecutionState) -> PolarsResult<Series> {
         // This method does the following:
         // 1. determine group_by tuples based on the group_column
@@ -638,11 +642,11 @@ impl PhysicalExpr for WindowExpr {
         false
     }
 
-    #[allow(clippy::ptr_arg)]
     #[cfg_attr(
         all(feature = "tracy", not(feature = "tracy-no-instrument")),
         tracy_gizmos::instrument
     )]
+    #[allow(clippy::ptr_arg)]
     fn evaluate_on_groups<'a>(
         &self,
         _df: &DataFrame,

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -979,14 +979,20 @@ fn cast_index(idx: Series, len: usize, null_on_oob: bool) -> PolarsResult<Series
 #[cfg(test)]
 mod tests {
     use polars_core::prelude::{AnyValue, IntoSeries, LambdaExpression, ListChunked, Series};
+
     use crate::chunked_array::ListNameSpaceImpl;
 
     #[test]
     fn test_empty_transform() {
-        let start_array = ListChunked::from_iter([Series::from_iter(["key1==value1", "key2===value2"])]).into_series();
+        let start_array =
+            ListChunked::from_iter([Series::from_iter(["key1==value1", "key2===value2"])])
+                .into_series();
         let empty_lambda = LambdaExpression::StaticStr("meep".into());
 
-        let result = start_array.as_list().lst_transform(empty_lambda.into(), false).expect("Could not evaluate lambda");
+        let result = start_array
+            .as_list()
+            .lst_transform(empty_lambda.into(), false)
+            .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
 
         assert_eq!(res.len(), 2);
@@ -997,10 +1003,15 @@ mod tests {
 
     #[test]
     fn test_lambda_length() {
-        let start_array = ListChunked::from_iter([Series::from_iter(["key1==value1", "key2===value2"])]).into_series();
+        let start_array =
+            ListChunked::from_iter([Series::from_iter(["key1==value1", "key2===value2"])])
+                .into_series();
         let length_lambda = LambdaExpression::Length(Box::new(LambdaExpression::Variable(0)));
 
-        let result = start_array.as_list().lst_transform(length_lambda.into(), false).expect("Could not evaluate lambda");
+        let result = start_array
+            .as_list()
+            .lst_transform(length_lambda.into(), false)
+            .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
         assert_eq!(res.i32().unwrap().get(0).unwrap(), 12);
         assert_eq!(res.i32().unwrap().get(1).unwrap(), 13);
@@ -1015,7 +1026,10 @@ mod tests {
             Box::new(LambdaExpression::Int32(2)),
         );
 
-        let result = start_array.as_list().lst_transform(substring_lambda.into(), false).expect("Could not evaluate lambda");
+        let result = start_array
+            .as_list()
+            .lst_transform(substring_lambda.into(), false)
+            .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
 
         // Substring should start at the index of the element in the array + 2
@@ -1025,7 +1039,9 @@ mod tests {
 
     #[test]
     fn test_lambda_with_index() {
-        let start_array = ListChunked::from_iter([Series::from_iter(vec!["key1==value1", "key2===value2"])]).into_series();
+        let start_array =
+            ListChunked::from_iter([Series::from_iter(vec!["key1==value1", "key2===value2"])])
+                .into_series();
         let substring_lambda = LambdaExpression::Substring(
             Box::new(LambdaExpression::Variable(0)),
             Box::new(LambdaExpression::Add(
@@ -1035,7 +1051,10 @@ mod tests {
             Box::new(LambdaExpression::Int32(2)),
         );
 
-        let result = start_array.as_list().lst_transform(substring_lambda.into(), true).expect("Could not evaluate lambda");
+        let result = start_array
+            .as_list()
+            .lst_transform(substring_lambda.into(), true)
+            .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
 
         assert_eq!(res.str().unwrap().get(0).unwrap(), "y1");
@@ -1048,7 +1067,8 @@ mod tests {
             "key1==value1",
             "key2===u",
             "key3==value3whichisverylong",
-        ])]).into_series();
+        ])])
+        .into_series();
 
         let casewhen_lambda = LambdaExpression::CaseWhen(
             vec![(
@@ -1063,7 +1083,10 @@ mod tests {
             Box::new(LambdaExpression::StaticStr("nope".into())),
         );
 
-        let result = start_array.as_list().lst_transform(casewhen_lambda.into(), false).expect("Could not evaluate lambda");
+        let result = start_array
+            .as_list()
+            .lst_transform(casewhen_lambda.into(), false)
+            .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
 
         assert_eq!(res.str().unwrap().get(0).unwrap(), "key1==value1");
@@ -1084,7 +1107,8 @@ mod tests {
             None,
             Some(4),
             Some(5),
-        ])]).into_series();
+        ])])
+        .into_series();
         // CASE
         // WHEN
         //     isnull(lambda x_8#28858)

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -1,6 +1,6 @@
 use std::fmt::Write;
 
-use arrow::array::ValueSize;
+use arrow::array::{Array, MutableArray, MutablePrimitiveArray, ValueSize};
 use arrow::legacy::kernels::list::{index_is_oob, sublist_get};
 use polars_core::chunked_array::builder::get_list_builder;
 #[cfg(feature = "list_gather")]
@@ -255,34 +255,92 @@ pub trait ListNameSpaceImpl: AsList {
         }
     }
 
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn lst_filter_by_func(
         &self,
-        lambda_expressions: Arc<LambdaExpression>,
+        lambda_expression: Arc<LambdaExpression>,
+        with_index: bool,
     ) -> PolarsResult<ListChunked> {
-        let ca = self.as_list();
-
-        // Apply the filter to each inner list while maintaining outer structure
-        let filtered = ca.try_apply_amortized(|s| {
-            // Convert AmortizedSeries to Series reference
-            let s_ref = s.as_ref();
-            let index_series = Series::from_iter(1i32..=s_ref.len() as i32);
-            s_ref.filter(
-                lambda_expressions
-                    .eval(s_ref, &index_series, true)?
-                    .bool()?,
+        let mut index_data = with_index.then(|| {
+            (
+                MutablePrimitiveArray::<i32>::with_capacity(8),
+                AmortSeries::new(Series::new_empty(PlSmallStr::EMPTY, &DataType::Int32).into()),
             )
-        })?;
+        });
 
-        Ok(filtered)
+        self.as_list().try_apply_amortized(|s| {
+            let s_ref = s.as_ref();
+
+            s_ref.filter(
+                if let Some((index_arr, index_amort)) = &mut index_data {
+                    let s_len = s_ref.len() as i32;
+                    let index_count = index_arr.len() as i32;
+                    if index_count < s_len {
+                        index_arr.extend_trusted_len_values(index_count..s_len)
+                    } else {
+                        index_arr.truncate(s_len as usize);
+                    }
+
+                    // Create a temporary Box<dyn Array> for this iteration, this is unsafe code but I think should be ok here??
+                    let mut temp_box: Box<dyn Array> =
+                        unsafe { std::mem::transmute(index_arr.as_box()) };
+
+                    unsafe {
+                        index_amort.with_array(&mut temp_box, |arr| {
+                            lambda_expression.eval(s_ref, Some(arr.as_ref()), true)
+                        })
+                    }
+                } else {
+                    lambda_expression.eval(s_ref, None, true)
+                }?
+                .bool()?,
+            )
+        })
     }
 
-    fn lst_transform(&self, lambda_expression: Arc<LambdaExpression>) -> PolarsResult<ListChunked> {
-        let ca = self.as_list();
-        ca.try_apply_amortized(|s| {
-            // Convert AmortizedSeries to Series reference
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
+    fn lst_transform(
+        &self,
+        lambda_expression: Arc<LambdaExpression>,
+        with_index: bool,
+    ) -> PolarsResult<ListChunked> {
+        let mut index_data = with_index.then(|| {
+            (
+                MutablePrimitiveArray::<i32>::with_capacity(8),
+                AmortSeries::new(Series::new_empty(PlSmallStr::EMPTY, &DataType::Int32).into()),
+            )
+        });
+
+        self.as_list().try_apply_amortized(|s| {
             let s_ref = s.as_ref();
-            let index_series = Series::from_iter(1i32..=s_ref.len() as i32);
-            lambda_expression.eval(s.as_ref(), &index_series, true)
+
+            if let Some((index_arr, index_amort)) = &mut index_data {
+                let s_len = s_ref.len() as i32;
+                let index_count = index_arr.len() as i32;
+                if index_count < s_len {
+                    index_arr.extend_trusted_len_values(index_count..s_len)
+                } else {
+                    index_arr.truncate(s_len as usize);
+                }
+
+                // Create a temporary Box<dyn Array> for this iteration, this is unsafe code but I think should be ok here??
+                let mut temp_box: Box<dyn Array> =
+                    unsafe { std::mem::transmute(index_arr.as_box()) };
+
+                unsafe {
+                    index_amort.with_array(&mut temp_box, |arr| {
+                        lambda_expression.eval(s_ref, Some(arr.as_ref()), true)
+                    })
+                }
+            } else {
+                lambda_expression.eval(s_ref, None, true)
+            }
         })
     }
 

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::fmt::Write;
 
-use arrow::array::{Array, MutableArray, MutablePrimitiveArray, ValueSize};
+use arrow::array::{MutableArray, MutablePrimitiveArray, ValueSize};
 use arrow::legacy::kernels::list::{index_is_oob, sublist_get};
 use polars_core::chunked_array::builder::get_list_builder;
 #[cfg(feature = "list_gather")]
@@ -270,11 +270,8 @@ pub trait ListNameSpaceImpl: AsList {
                 Ordering::Equal => {} // Do nothing
             }
 
-            // Create a temporary Box<dyn Array> for this iteration, this is unsafe code but I think should be ok here??
-            let mut temp_box: Box<dyn Array> = unsafe { std::mem::transmute(index_arr.as_box()) };
-
             unsafe {
-                index_amort.with_array(&mut temp_box, |arr| {
+                index_amort.with_array(&mut index_arr.as_box(), |arr| {
                     lambda_expression.eval(s_ref, Some(arr.as_ref()))
                 })
             }

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -261,7 +261,7 @@ pub trait ListNameSpaceImpl: AsList {
         index_data: Option<&mut (MutablePrimitiveArray<i32>, AmortSeries)>,
     ) -> PolarsResult<Series> {
         let s_len = s_ref.len() as i32;
-        if let Some((index_arr, index_amort)) = index_data {
+        (if let Some((index_arr, index_amort)) = index_data {
             let index_count = index_arr.len() as i32;
             if index_count < s_len {
                 index_arr.extend_trusted_len_values(index_count..s_len)
@@ -279,12 +279,27 @@ pub trait ListNameSpaceImpl: AsList {
             }
         } else {
             lambda_expression.eval(s_ref, None)
-        }.and_then(|eval_result| {
+        }).and_then(|eval_result| {
             let eval_result_len = eval_result.len() as i32;
             if eval_result_len != s_len {
-                if eval_result.len() == 1 {
-                    let literal_val = eval_result.get(0).unwrap();
-                    eval_result.extend_constant(literal_val, (s_len - 1) as usize)
+                if eval_result_len == 1 {
+                    Ok(match eval_result.dtype() {
+                        DataType::Boolean => Series::from_iter(std::iter::repeat_n(eval_result.bool()?.get(0), s_len as usize)),
+                        DataType::UInt8 => Series::from_iter(std::iter::repeat_n(eval_result.u8()?.get(0), s_len as usize)),
+                        DataType::UInt16 => Series::from_iter(std::iter::repeat_n(eval_result.u16()?.get(0), s_len as usize)),
+                        DataType::UInt32 => Series::from_iter(std::iter::repeat_n(eval_result.u32()?.get(0), s_len as usize)),
+                        DataType::UInt64 => Series::from_iter(std::iter::repeat_n(eval_result.u64()?.get(0), s_len as usize)),
+                        DataType::Int8 => Series::from_iter(std::iter::repeat_n(eval_result.i8()?.get(0), s_len as usize)),
+                        DataType::Int16 => Series::from_iter(std::iter::repeat_n(eval_result.i16()?.get(0), s_len as usize)),
+                        DataType::Int32 => Series::from_iter(std::iter::repeat_n(eval_result.i32()?.get(0), s_len as usize)),
+                        DataType::Int64 => Series::from_iter(std::iter::repeat_n(eval_result.i64()?.get(0), s_len as usize)),
+                        DataType::Float32 => Series::from_iter(std::iter::repeat_n(eval_result.f32()?.get(0), s_len as usize)),
+                        DataType::Float64 => Series::from_iter(std::iter::repeat_n(eval_result.f64()?.get(0), s_len as usize)),
+                        DataType::String => Series::from_iter(std::iter::repeat_n(eval_result.str()?.get(0), s_len as usize)),
+                        DataType::Binary => BinaryChunked::from_iter(std::iter::repeat_n(eval_result.binary()?.get(0), s_len as usize)).into_series(),
+                        DataType::List(_) => ListChunked::from_iter(std::iter::repeat_n(eval_result.list()?.get_as_series(0), s_len as usize)).into_series(),
+                        other => polars_bail!(SchemaMismatch: "invalid dtype for lambda function: {}", other),
+                    })
                 } else {
                     polars_bail!(ShapeMismatch: "lambda function did not return a series of equal length")
                 }
@@ -978,7 +993,7 @@ fn cast_index(idx: Series, len: usize, null_on_oob: bool) -> PolarsResult<Series
 // Was using these to debug but I see no harm in having more unit tests, in fact we should probably have more here
 #[cfg(test)]
 mod tests {
-    use polars_core::prelude::{AnyValue, IntoSeries, LambdaExpression, ListChunked, Series};
+    use polars_core::prelude::{IntoSeries, LambdaExpression, ListChunked, Series, SortOptions};
 
     use crate::chunked_array::ListNameSpaceImpl;
 
@@ -1109,33 +1124,7 @@ mod tests {
             Some(5),
         ])])
         .into_series();
-        // CASE
-        // WHEN
-        //     isnull(lambda x_8#28858)
-        // THEN
-        //     CASE
-        //     WHEN
-        //         isnull(lambda y_9#28859)
-        //     THEN
-        //         0
-        //     ELSE
-        //         1
-        //     END
-        // WHEN
-        //     isnull(lambda y_9#28859)
-        // THEN
-        //     -1
-        // WHEN
-        //     (lambda x_8#28858 > lambda y_9#28859)
-        // THEN
-        //     1
-        // WHEN
-        //     (lambda x_8#28858 < lambda y_9#28859)
-        // THEN
-        //     -1
-        // ELSE
-        //     0
-        // END
+
         let ascending_lambda = LambdaExpression::CaseWhen(
             vec![
                 (
@@ -1170,25 +1159,23 @@ mod tests {
             LambdaExpression::Int32(0).into(),
         );
 
-        let mut vals = start_array.iter().collect::<Vec<_>>();
-        vals.sort_by(|curr, next| {
-            ascending_lambda
-                .eval_window(curr, next)
-                .unwrap()
-                .try_into()
-                .unwrap()
-        });
+        let result = start_array
+            .as_list()
+            .lst_sort_by_func(SortOptions::new().with_nulls_last(true), ascending_lambda.into())
+            .expect("Could not evaluate lambda");
+        let res = result.get_as_series(0).unwrap();
+
         assert_eq!(
-            vals,
-            vec![
-                AnyValue::Int32(1),
-                AnyValue::Int32(2),
-                AnyValue::Int32(3),
-                AnyValue::Int32(4),
-                AnyValue::Int32(5),
-                AnyValue::Null,
-                AnyValue::Null
-            ]
+            res,
+            Series::from_iter(vec![
+                Some(1i32),
+                Some(2),
+                Some(3),
+                Some(4),
+                Some(5),
+                None,
+                None
+            ])
         );
     }
 }

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -255,6 +255,33 @@ pub trait ListNameSpaceImpl: AsList {
         }
     }
 
+    fn eval_lambda_on_amort(
+        s_ref: &Series,
+        lambda_expression: Arc<LambdaExpression>,
+        index_data: Option<&mut (MutablePrimitiveArray<i32>, AmortSeries)>,
+    ) -> PolarsResult<Series> {
+        if let Some((index_arr, index_amort)) = index_data {
+            let s_len = s_ref.len() as i32;
+            let index_count = index_arr.len() as i32;
+            if index_count < s_len {
+                index_arr.extend_trusted_len_values(index_count..s_len)
+            } else {
+                index_arr.truncate(s_len as usize);
+            }
+
+            // Create a temporary Box<dyn Array> for this iteration, this is unsafe code but I think should be ok here??
+            let mut temp_box: Box<dyn Array> = unsafe { std::mem::transmute(index_arr.as_box()) };
+
+            unsafe {
+                index_amort.with_array(&mut temp_box, |arr| {
+                    lambda_expression.eval(s_ref, Some(arr.as_ref()))
+                })
+            }
+        } else {
+            lambda_expression.eval(s_ref, None)
+        }
+    }
+
     #[cfg_attr(
         all(feature = "tracy", not(feature = "tracy-no-instrument")),
         tracy_gizmos::instrument
@@ -275,28 +302,8 @@ pub trait ListNameSpaceImpl: AsList {
             let s_ref = s.as_ref();
 
             s_ref.filter(
-                if let Some((index_arr, index_amort)) = &mut index_data {
-                    let s_len = s_ref.len() as i32;
-                    let index_count = index_arr.len() as i32;
-                    if index_count < s_len {
-                        index_arr.extend_trusted_len_values(index_count..s_len)
-                    } else {
-                        index_arr.truncate(s_len as usize);
-                    }
-
-                    // Create a temporary Box<dyn Array> for this iteration, this is unsafe code but I think should be ok here??
-                    let mut temp_box: Box<dyn Array> =
-                        unsafe { std::mem::transmute(index_arr.as_box()) };
-
-                    unsafe {
-                        index_amort.with_array(&mut temp_box, |arr| {
-                            lambda_expression.eval(s_ref, Some(arr.as_ref()), true)
-                        })
-                    }
-                } else {
-                    lambda_expression.eval(s_ref, None, true)
-                }?
-                .bool()?,
+                Self::eval_lambda_on_amort(s_ref, lambda_expression.clone(), index_data.as_mut())?
+                    .bool()?,
             )
         })
     }
@@ -319,28 +326,7 @@ pub trait ListNameSpaceImpl: AsList {
 
         self.as_list().try_apply_amortized(|s| {
             let s_ref = s.as_ref();
-
-            if let Some((index_arr, index_amort)) = &mut index_data {
-                let s_len = s_ref.len() as i32;
-                let index_count = index_arr.len() as i32;
-                if index_count < s_len {
-                    index_arr.extend_trusted_len_values(index_count..s_len)
-                } else {
-                    index_arr.truncate(s_len as usize);
-                }
-
-                // Create a temporary Box<dyn Array> for this iteration, this is unsafe code but I think should be ok here??
-                let mut temp_box: Box<dyn Array> =
-                    unsafe { std::mem::transmute(index_arr.as_box()) };
-
-                unsafe {
-                    index_amort.with_array(&mut temp_box, |arr| {
-                        lambda_expression.eval(s_ref, Some(arr.as_ref()), true)
-                    })
-                }
-            } else {
-                lambda_expression.eval(s_ref, None, true)
-            }
+            Self::eval_lambda_on_amort(s_ref, lambda_expression.clone(), index_data.as_mut())
         })
     }
 

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -281,29 +281,27 @@ pub trait ListNameSpaceImpl: AsList {
             lambda_expression.eval(s_ref, None)
         }).and_then(|eval_result| {
             let eval_result_len = eval_result.len() as i32;
-            if eval_result_len != s_len {
-                if eval_result_len == 1 {
-                    // This will only happen when we return literals, so no need to support unsigned integers
-                    Ok(match eval_result.dtype() {
-                        DataType::Boolean => Series::from_iter(std::iter::repeat_n(eval_result.bool()?.get(0), s_len as usize)),
-                        #[cfg(feature = "dtype-i8")]
-                        DataType::Int8 => Series::from_iter(std::iter::repeat_n(eval_result.i8()?.get(0), s_len as usize)),
-                        #[cfg(feature = "dtype-i16")]
-                        DataType::Int16 => Series::from_iter(std::iter::repeat_n(eval_result.i16()?.get(0), s_len as usize)),
-                        DataType::Int32 => Series::from_iter(std::iter::repeat_n(eval_result.i32()?.get(0), s_len as usize)),
-                        DataType::Int64 => Series::from_iter(std::iter::repeat_n(eval_result.i64()?.get(0), s_len as usize)),
-                        DataType::Float32 => Series::from_iter(std::iter::repeat_n(eval_result.f32()?.get(0), s_len as usize)),
-                        DataType::Float64 => Series::from_iter(std::iter::repeat_n(eval_result.f64()?.get(0), s_len as usize)),
-                        DataType::String => Series::from_iter(std::iter::repeat_n(eval_result.str()?.get(0), s_len as usize)),
-                        DataType::Binary => BinaryChunked::from_iter(std::iter::repeat_n(eval_result.binary()?.get(0), s_len as usize)).into_series(),
-                        DataType::List(_) => ListChunked::from_iter(std::iter::repeat_n(eval_result.list()?.get_as_series(0), s_len as usize)).into_series(),
-                        other => polars_bail!(SchemaMismatch: "invalid dtype for lambda function: {}", other),
-                    })
-                } else {
-                    polars_bail!(ShapeMismatch: "lambda function did not return a series of equal length")
-                }
-            } else {
-                Ok(eval_result)
+            match eval_result_len {
+                // Equal length, job's a good'n
+                len if len == s_len => Ok(eval_result),
+                // We returned a literal, needs to be repeated to match the length of the input, unlikely case
+                1 => Ok(match eval_result.dtype() {
+                    DataType::Boolean => Series::from_iter(std::iter::repeat_n(eval_result.bool()?.get(0), s_len as usize)),
+                    #[cfg(feature = "dtype-i8")]
+                    DataType::Int8 => Series::from_iter(std::iter::repeat_n(eval_result.i8()?.get(0), s_len as usize)),
+                    #[cfg(feature = "dtype-i16")]
+                    DataType::Int16 => Series::from_iter(std::iter::repeat_n(eval_result.i16()?.get(0), s_len as usize)),
+                    DataType::Int32 => Series::from_iter(std::iter::repeat_n(eval_result.i32()?.get(0), s_len as usize)),
+                    DataType::Int64 => Series::from_iter(std::iter::repeat_n(eval_result.i64()?.get(0), s_len as usize)),
+                    DataType::Float32 => Series::from_iter(std::iter::repeat_n(eval_result.f32()?.get(0), s_len as usize)),
+                    DataType::Float64 => Series::from_iter(std::iter::repeat_n(eval_result.f64()?.get(0), s_len as usize)),
+                    DataType::String => Series::from_iter(std::iter::repeat_n(eval_result.str()?.get(0), s_len as usize)),
+                    DataType::Binary => BinaryChunked::from_iter(std::iter::repeat_n(eval_result.binary()?.get(0), s_len as usize)).into_series(),
+                    DataType::List(_) => ListChunked::from_iter(std::iter::repeat_n(eval_result.list()?.get_as_series(0), s_len as usize)).into_series(),
+                    other => polars_bail!(SchemaMismatch: "invalid dtype for lambda function: {}", other),
+                }),
+                // We returned a series of the wrong length, error
+                _ => polars_bail!(ShapeMismatch: "lambda function did not return a series of equal length")
             }
         })
     }
@@ -1003,7 +1001,10 @@ mod tests {
                 .into_series();
         let empty_lambda = LambdaExpression::StaticStr("meep".into());
 
-        let result = start_array.list().unwrap().lst_transform(empty_lambda.into(), false)
+        let result = start_array
+            .list()
+            .unwrap()
+            .lst_transform(empty_lambda.into(), false)
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
 
@@ -1020,7 +1021,9 @@ mod tests {
                 .into_series();
         let length_lambda = LambdaExpression::Length(Box::new(LambdaExpression::Variable(0)));
 
-        let result = start_array.list().unwrap()
+        let result = start_array
+            .list()
+            .unwrap()
             .lst_transform(length_lambda.into(), false)
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
@@ -1030,14 +1033,18 @@ mod tests {
 
     #[test]
     fn test_lambda_substring() {
-        let start_array = ListChunked::from_iter([Series::from_iter(vec!["key1==value1", "key2===value2"])]).into_series();
+        let start_array =
+            ListChunked::from_iter([Series::from_iter(vec!["key1==value1", "key2===value2"])])
+                .into_series();
         let substring_lambda = LambdaExpression::Substring(
             Box::new(LambdaExpression::Variable(0)),
             Box::new(LambdaExpression::Int32(4)),
             Box::new(LambdaExpression::Int32(2)),
         );
 
-        let result = start_array.list().unwrap()
+        let result = start_array
+            .list()
+            .unwrap()
             .lst_transform(substring_lambda.into(), false)
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
@@ -1061,7 +1068,9 @@ mod tests {
             Box::new(LambdaExpression::Int32(2)),
         );
 
-        let result = start_array.list().unwrap()
+        let result = start_array
+            .list()
+            .unwrap()
             .lst_transform(substring_lambda.into(), true)
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
@@ -1092,7 +1101,9 @@ mod tests {
             Box::new(LambdaExpression::StaticStr("nope".into())),
         );
 
-        let result = start_array.list().unwrap()
+        let result = start_array
+            .list()
+            .unwrap()
             .lst_transform(casewhen_lambda.into(), false)
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
@@ -1152,8 +1163,13 @@ mod tests {
             LambdaExpression::Int32(0).into(),
         );
 
-        let result = start_array.list().unwrap()
-            .lst_sort_by_func(SortOptions::new().with_nulls_last(true), ascending_lambda.into())
+        let result = start_array
+            .list()
+            .unwrap()
+            .lst_sort_by_func(
+                SortOptions::new().with_nulls_last(true),
+                ascending_lambda.into(),
+            )
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
 

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::fmt::Write;
 
 use arrow::array::{Array, MutableArray, MutablePrimitiveArray, ValueSize};
@@ -263,10 +264,10 @@ pub trait ListNameSpaceImpl: AsList {
         let s_len = s_ref.len() as i32;
         (if let Some((index_arr, index_amort)) = index_data {
             let index_count = index_arr.len() as i32;
-            if index_count < s_len {
-                index_arr.extend_trusted_len_values(index_count+1..=s_len)
-            } else {
-                index_arr.truncate(s_len as usize);
+            match index_count.cmp(&s_len) {
+                Ordering::Less => index_arr.extend_trusted_len_values(index_count..s_len),
+                Ordering::Greater => index_arr.truncate(s_len as usize),
+                Ordering::Equal => {} // Do nothing
             }
 
             // Create a temporary Box<dyn Array> for this iteration, this is unsafe code but I think should be ok here??
@@ -1075,8 +1076,9 @@ mod tests {
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
 
-        assert_eq!(res.str().unwrap().get(0).unwrap(), "y1");
-        assert_eq!(res.str().unwrap().get(1).unwrap(), "2=");
+        // Apparently this should be 0 indexed, not 1 as I thought
+        assert_eq!(res.str().unwrap().get(0).unwrap(), "ey");
+        assert_eq!(res.str().unwrap().get(1).unwrap(), "y2");
     }
 
     #[test]

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -264,7 +264,7 @@ pub trait ListNameSpaceImpl: AsList {
         (if let Some((index_arr, index_amort)) = index_data {
             let index_count = index_arr.len() as i32;
             if index_count < s_len {
-                index_arr.extend_trusted_len_values(index_count..s_len)
+                index_arr.extend_trusted_len_values(index_count+1..=s_len)
             } else {
                 index_arr.truncate(s_len as usize);
             }
@@ -283,13 +283,12 @@ pub trait ListNameSpaceImpl: AsList {
             let eval_result_len = eval_result.len() as i32;
             if eval_result_len != s_len {
                 if eval_result_len == 1 {
+                    // This will only happen when we return literals, so no need to support unsigned integers
                     Ok(match eval_result.dtype() {
                         DataType::Boolean => Series::from_iter(std::iter::repeat_n(eval_result.bool()?.get(0), s_len as usize)),
-                        DataType::UInt8 => Series::from_iter(std::iter::repeat_n(eval_result.u8()?.get(0), s_len as usize)),
-                        DataType::UInt16 => Series::from_iter(std::iter::repeat_n(eval_result.u16()?.get(0), s_len as usize)),
-                        DataType::UInt32 => Series::from_iter(std::iter::repeat_n(eval_result.u32()?.get(0), s_len as usize)),
-                        DataType::UInt64 => Series::from_iter(std::iter::repeat_n(eval_result.u64()?.get(0), s_len as usize)),
+                        #[cfg(feature = "dtype-i8")]
                         DataType::Int8 => Series::from_iter(std::iter::repeat_n(eval_result.i8()?.get(0), s_len as usize)),
+                        #[cfg(feature = "dtype-i16")]
                         DataType::Int16 => Series::from_iter(std::iter::repeat_n(eval_result.i16()?.get(0), s_len as usize)),
                         DataType::Int32 => Series::from_iter(std::iter::repeat_n(eval_result.i32()?.get(0), s_len as usize)),
                         DataType::Int64 => Series::from_iter(std::iter::repeat_n(eval_result.i64()?.get(0), s_len as usize)),
@@ -1004,9 +1003,7 @@ mod tests {
                 .into_series();
         let empty_lambda = LambdaExpression::StaticStr("meep".into());
 
-        let result = start_array
-            .as_list()
-            .lst_transform(empty_lambda.into(), false)
+        let result = start_array.list().unwrap().lst_transform(empty_lambda.into(), false)
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
 
@@ -1023,8 +1020,7 @@ mod tests {
                 .into_series();
         let length_lambda = LambdaExpression::Length(Box::new(LambdaExpression::Variable(0)));
 
-        let result = start_array
-            .as_list()
+        let result = start_array.list().unwrap()
             .lst_transform(length_lambda.into(), false)
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
@@ -1034,15 +1030,14 @@ mod tests {
 
     #[test]
     fn test_lambda_substring() {
-        let start_array = Series::from_iter(vec!["key1==value1", "key2===value2"]);
+        let start_array = ListChunked::from_iter([Series::from_iter(vec!["key1==value1", "key2===value2"])]).into_series();
         let substring_lambda = LambdaExpression::Substring(
             Box::new(LambdaExpression::Variable(0)),
             Box::new(LambdaExpression::Int32(4)),
             Box::new(LambdaExpression::Int32(2)),
         );
 
-        let result = start_array
-            .as_list()
+        let result = start_array.list().unwrap()
             .lst_transform(substring_lambda.into(), false)
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
@@ -1066,8 +1061,7 @@ mod tests {
             Box::new(LambdaExpression::Int32(2)),
         );
 
-        let result = start_array
-            .as_list()
+        let result = start_array.list().unwrap()
             .lst_transform(substring_lambda.into(), true)
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
@@ -1098,8 +1092,7 @@ mod tests {
             Box::new(LambdaExpression::StaticStr("nope".into())),
         );
 
-        let result = start_array
-            .as_list()
+        let result = start_array.list().unwrap()
             .lst_transform(casewhen_lambda.into(), false)
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
@@ -1159,8 +1152,7 @@ mod tests {
             LambdaExpression::Int32(0).into(),
         );
 
-        let result = start_array
-            .as_list()
+        let result = start_array.list().unwrap()
             .lst_sort_by_func(SortOptions::new().with_nulls_last(true), ascending_lambda.into())
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -279,8 +279,9 @@ pub trait ListNameSpaceImpl: AsList {
             }
         } else {
             lambda_expression.eval(s_ref, None)
-        }.and_then(|eval_result|
-            if eval_result.len() != s_len as usize {
+        }.and_then(|eval_result| {
+            let eval_result_len = eval_result.len() as i32;
+            if eval_result_len != s_len {
                 if eval_result.len() == 1 {
                     let literal_val = eval_result.get(0).unwrap();
                     eval_result.extend_constant(literal_val, (s_len - 1) as usize)
@@ -290,7 +291,7 @@ pub trait ListNameSpaceImpl: AsList {
             } else {
                 Ok(eval_result)
             }
-        )
+        })
     }
 
     #[cfg_attr(
@@ -974,4 +975,196 @@ fn cast_index(idx: Series, len: usize, null_on_oob: bool) -> PolarsResult<Series
     Ok(out)
 }
 
-// TODO: implement the above for ArrayChunked as well?
+// Was using these to debug but I see no harm in having more unit tests, in fact we should probably have more here
+#[cfg(test)]
+mod tests {
+    use polars_core::prelude::{AnyValue, IntoSeries, LambdaExpression, ListChunked, Series};
+    use crate::chunked_array::ListNameSpaceImpl;
+
+    #[test]
+    fn test_empty_transform() {
+        let start_array = ListChunked::from_iter([Series::from_iter(["key1==value1", "key2===value2"])]).into_series();
+        let empty_lambda = LambdaExpression::StaticStr("meep".into());
+
+        let result = start_array.as_list().lst_transform(empty_lambda.into(), false).expect("Could not evaluate lambda");
+        let res = result.get_as_series(0).unwrap();
+
+        assert_eq!(res.len(), 2);
+
+        assert_eq!(res.str().unwrap().get(0).unwrap(), "meep");
+        assert_eq!(res.str().unwrap().get(1).unwrap(), "meep");
+    }
+
+    #[test]
+    fn test_lambda_length() {
+        let start_array = ListChunked::from_iter([Series::from_iter(["key1==value1", "key2===value2"])]).into_series();
+        let length_lambda = LambdaExpression::Length(Box::new(LambdaExpression::Variable(0)));
+
+        let result = start_array.as_list().lst_transform(length_lambda.into(), false).expect("Could not evaluate lambda");
+        let res = result.get_as_series(0).unwrap();
+        assert_eq!(res.i32().unwrap().get(0).unwrap(), 12);
+        assert_eq!(res.i32().unwrap().get(1).unwrap(), 13);
+    }
+
+    #[test]
+    fn test_lambda_substring() {
+        let start_array = Series::from_iter(vec!["key1==value1", "key2===value2"]);
+        let substring_lambda = LambdaExpression::Substring(
+            Box::new(LambdaExpression::Variable(0)),
+            Box::new(LambdaExpression::Int32(4)),
+            Box::new(LambdaExpression::Int32(2)),
+        );
+
+        let result = start_array.as_list().lst_transform(substring_lambda.into(), false).expect("Could not evaluate lambda");
+        let res = result.get_as_series(0).unwrap();
+
+        // Substring should start at the index of the element in the array + 2
+        assert_eq!(res.str().unwrap().get(0).unwrap(), "1=");
+        assert_eq!(res.str().unwrap().get(1).unwrap(), "2=");
+    }
+
+    #[test]
+    fn test_lambda_with_index() {
+        let start_array = ListChunked::from_iter([Series::from_iter(vec!["key1==value1", "key2===value2"])]).into_series();
+        let substring_lambda = LambdaExpression::Substring(
+            Box::new(LambdaExpression::Variable(0)),
+            Box::new(LambdaExpression::Add(
+                Box::new(LambdaExpression::Variable(1)),
+                Box::new(LambdaExpression::Int32(2)),
+            )),
+            Box::new(LambdaExpression::Int32(2)),
+        );
+
+        let result = start_array.as_list().lst_transform(substring_lambda.into(), true).expect("Could not evaluate lambda");
+        let res = result.get_as_series(0).unwrap();
+
+        assert_eq!(res.str().unwrap().get(0).unwrap(), "y1");
+        assert_eq!(res.str().unwrap().get(1).unwrap(), "2=");
+    }
+
+    #[test]
+    fn test_lambda_casewhen() {
+        let start_array = ListChunked::from_iter([Series::from_iter(vec![
+            "key1==value1",
+            "key2===u",
+            "key3==value3whichisverylong",
+        ])]).into_series();
+
+        let casewhen_lambda = LambdaExpression::CaseWhen(
+            vec![(
+                LambdaExpression::GreaterThan(
+                    Box::new(LambdaExpression::Length(Box::new(
+                        LambdaExpression::Variable(0),
+                    ))),
+                    Box::new(LambdaExpression::Int32(10)),
+                ),
+                LambdaExpression::Variable(0),
+            )],
+            Box::new(LambdaExpression::StaticStr("nope".into())),
+        );
+
+        let result = start_array.as_list().lst_transform(casewhen_lambda.into(), false).expect("Could not evaluate lambda");
+        let res = result.get_as_series(0).unwrap();
+
+        assert_eq!(res.str().unwrap().get(0).unwrap(), "key1==value1");
+        assert_eq!(res.str().unwrap().get(1).unwrap(), "nope");
+        assert_eq!(
+            res.str().unwrap().get(2).unwrap(),
+            "key3==value3whichisverylong"
+        );
+    }
+
+    #[test]
+    fn test_array_sort() {
+        let start_array = ListChunked::from_iter([Series::from_iter(vec![
+            Some(1i32),
+            None,
+            Some(2),
+            Some(3),
+            None,
+            Some(4),
+            Some(5),
+        ])]).into_series();
+        // CASE
+        // WHEN
+        //     isnull(lambda x_8#28858)
+        // THEN
+        //     CASE
+        //     WHEN
+        //         isnull(lambda y_9#28859)
+        //     THEN
+        //         0
+        //     ELSE
+        //         1
+        //     END
+        // WHEN
+        //     isnull(lambda y_9#28859)
+        // THEN
+        //     -1
+        // WHEN
+        //     (lambda x_8#28858 > lambda y_9#28859)
+        // THEN
+        //     1
+        // WHEN
+        //     (lambda x_8#28858 < lambda y_9#28859)
+        // THEN
+        //     -1
+        // ELSE
+        //     0
+        // END
+        let ascending_lambda = LambdaExpression::CaseWhen(
+            vec![
+                (
+                    LambdaExpression::IsNull(LambdaExpression::Variable(0).into()),
+                    LambdaExpression::CaseWhen(
+                        vec![(
+                            LambdaExpression::IsNull(LambdaExpression::Variable(1).into()),
+                            LambdaExpression::Int32(0),
+                        )],
+                        LambdaExpression::Int32(1).into(),
+                    ),
+                ),
+                (
+                    LambdaExpression::IsNull(LambdaExpression::Variable(1).into()),
+                    LambdaExpression::Int32(-1),
+                ),
+                (
+                    LambdaExpression::GreaterThan(
+                        LambdaExpression::Variable(0).into(),
+                        LambdaExpression::Variable(1).into(),
+                    ),
+                    LambdaExpression::Int32(1),
+                ),
+                (
+                    LambdaExpression::LessThan(
+                        LambdaExpression::Variable(0).into(),
+                        LambdaExpression::Variable(1).into(),
+                    ),
+                    LambdaExpression::Int32(-1),
+                ),
+            ],
+            LambdaExpression::Int32(0).into(),
+        );
+
+        let mut vals = start_array.iter().collect::<Vec<_>>();
+        vals.sort_by(|curr, next| {
+            ascending_lambda
+                .eval_window(curr, next)
+                .unwrap()
+                .try_into()
+                .unwrap()
+        });
+        assert_eq!(
+            vals,
+            vec![
+                AnyValue::Int32(1),
+                AnyValue::Int32(2),
+                AnyValue::Int32(3),
+                AnyValue::Int32(4),
+                AnyValue::Int32(5),
+                AnyValue::Null,
+                AnyValue::Null
+            ]
+        );
+    }
+}

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -260,8 +260,8 @@ pub trait ListNameSpaceImpl: AsList {
         lambda_expression: Arc<LambdaExpression>,
         index_data: Option<&mut (MutablePrimitiveArray<i32>, AmortSeries)>,
     ) -> PolarsResult<Series> {
+        let s_len = s_ref.len() as i32;
         if let Some((index_arr, index_amort)) = index_data {
-            let s_len = s_ref.len() as i32;
             let index_count = index_arr.len() as i32;
             if index_count < s_len {
                 index_arr.extend_trusted_len_values(index_count..s_len)
@@ -279,7 +279,18 @@ pub trait ListNameSpaceImpl: AsList {
             }
         } else {
             lambda_expression.eval(s_ref, None)
-        }
+        }.and_then(|eval_result|
+            if eval_result.len() != s_len as usize {
+                if eval_result.len() == 1 {
+                    let literal_val = eval_result.get(0).unwrap();
+                    eval_result.extend_constant(literal_val, (s_len - 1) as usize)
+                } else {
+                    polars_bail!(ShapeMismatch: "lambda function did not return a series of equal length")
+                }
+            } else {
+                Ok(eval_result)
+            }
+        )
     }
 
     #[cfg_attr(

--- a/crates/polars-plan/src/dsl/arithmetic.rs
+++ b/crates/polars-plan/src/dsl/arithmetic.rs
@@ -47,7 +47,7 @@ impl Neg for Expr {
     type Output = Expr;
 
     fn neg(self) -> Self::Output {
-        self.map_private(FunctionExpr::Negate)
+        self.map_private(FunctionExpr::Negate).with_fmt("neg")
     }
 }
 
@@ -70,107 +70,125 @@ impl Expr {
     /// Compute the square root of the given expression
     pub fn sqrt(self) -> Self {
         self.map_private(FunctionExpr::Pow(PowFunction::Sqrt))
+            .with_fmt("sqrt")
     }
 
     /// Compute the cube root of the given expression
     pub fn cbrt(self) -> Self {
         self.map_private(FunctionExpr::Pow(PowFunction::Cbrt))
+            .with_fmt("cbrt")
     }
 
     /// Compute the cosine of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn cos(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::Cos))
+            .with_fmt("cos")
     }
 
     /// Compute the cotangent of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn cot(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::Cot))
+            .with_fmt("cot")
     }
 
     /// Compute the sine of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn sin(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::Sin))
+            .with_fmt("sin")
     }
 
     /// Compute the tangent of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn tan(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::Tan))
+            .with_fmt("tan")
     }
 
     /// Compute the inverse cosine of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn arccos(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::ArcCos))
+            .with_fmt("arc_cos")
     }
 
     /// Compute the inverse sine of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn arcsin(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::ArcSin))
+            .with_fmt("arc_sin")
     }
 
     /// Compute the inverse tangent of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn arctan(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::ArcTan))
+            .with_fmt("arc_tan")
     }
 
     /// Compute the inverse tangent of the given expression, with the angle expressed as the argument of a complex number
     #[cfg(feature = "trigonometry")]
     pub fn arctan2(self, x: Self) -> Self {
         self.map_many_private(FunctionExpr::Atan2, &[x], false, None)
+            .with_fmt("atan2")
     }
 
     /// Compute the hyperbolic cosine of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn cosh(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::Cosh))
+            .with_fmt("cosh")
     }
 
     /// Compute the hyperbolic sine of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn sinh(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::Sinh))
+            .with_fmt("sinh")
     }
 
     /// Compute the hyperbolic tangent of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn tanh(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::Tanh))
+            .with_fmt("tanh")
     }
 
     /// Compute the inverse hyperbolic cosine of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn arccosh(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::ArcCosh))
+            .with_fmt("arc_cosh")
     }
 
     /// Compute the inverse hyperbolic sine of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn arcsinh(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::ArcSinh))
+            .with_fmt("arc_sinh")
     }
 
     /// Compute the inverse hyperbolic tangent of the given expression
     #[cfg(feature = "trigonometry")]
     pub fn arctanh(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::ArcTanh))
+            .with_fmt("arc_tanh")
     }
 
     /// Convert from radians to degrees
     #[cfg(feature = "trigonometry")]
     pub fn degrees(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::Degrees))
+            .with_fmt("deg")
     }
 
     /// Convert from degrees to radians
     #[cfg(feature = "trigonometry")]
     pub fn radians(self) -> Self {
         self.map_private(FunctionExpr::Trigonometry(TrigonometricFunction::Radians))
+            .with_fmt("rad")
     }
 
     /// Compute the sign of the given expression

--- a/crates/polars-plan/src/dsl/binary.rs
+++ b/crates/polars-plan/src/dsl/binary.rs
@@ -37,18 +37,21 @@ impl BinaryNameSpace {
     pub fn size_bytes(self) -> Expr {
         self.0
             .map_private(FunctionExpr::BinaryExpr(BinaryFunction::Size))
+            .with_fmt("size_bytes")
     }
 
     #[cfg(feature = "binary_encoding")]
     pub fn hex_decode(self, strict: bool) -> Expr {
         self.0
             .map_private(FunctionExpr::BinaryExpr(BinaryFunction::HexDecode(strict)))
+            .with_fmt("hex_decode")
     }
 
     #[cfg(feature = "binary_encoding")]
     pub fn hex_encode(self) -> Expr {
         self.0
             .map_private(FunctionExpr::BinaryExpr(BinaryFunction::HexEncode))
+            .with_fmt("hex_encode")
     }
 
     #[cfg(feature = "binary_encoding")]
@@ -57,11 +60,13 @@ impl BinaryNameSpace {
             .map_private(FunctionExpr::BinaryExpr(BinaryFunction::Base64Decode(
                 strict,
             )))
+            .with_fmt("b64_decode")
     }
 
     #[cfg(feature = "binary_encoding")]
     pub fn base64_encode(self) -> Expr {
         self.0
             .map_private(FunctionExpr::BinaryExpr(BinaryFunction::Base64Encode))
+            .with_fmt("b64_encode")
     }
 }

--- a/crates/polars-plan/src/dsl/expr_dyn_fn.rs
+++ b/crates/polars-plan/src/dsl/expr_dyn_fn.rs
@@ -79,6 +79,10 @@ impl<F> SeriesUdf for F
 where
     F: Fn(&mut [Series]) -> PolarsResult<Option<Series>> + Send + Sync,
 {
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn call_udf(&self, s: &mut [Series]) -> PolarsResult<Option<Series>> {
         self(s)
     }
@@ -99,6 +103,10 @@ impl<F> SeriesBinaryUdf for F
 where
     F: Fn(Series, Series) -> PolarsResult<Series> + Send + Sync,
 {
+    #[cfg_attr(
+        all(feature = "tracy", not(feature = "tracy-no-instrument")),
+        tracy_gizmos::instrument
+    )]
     fn call_udf(&self, a: Series, b: Series) -> PolarsResult<Series> {
         self(a, b)
     }

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -57,9 +57,9 @@ pub enum ListFunction {
     #[cfg(feature = "dtype-array")]
     ToArray(usize),
     // Flarion functions
-    FilterByFunc(Arc<LambdaExpression>),
+    FilterByFunc(Arc<LambdaExpression>, bool),
     SortByFunc(SortOptions, Arc<LambdaExpression>),
-    Transform(Arc<LambdaExpression>),
+    Transform(Arc<LambdaExpression>, bool),
     FlarionSlice,
 }
 
@@ -109,9 +109,9 @@ impl ListFunction {
             ToArray(width) => mapper.try_map_dtype(|dt| map_list_dtype_to_array_dtype(dt, *width)),
             NUnique => mapper.with_dtype(IDX_DTYPE),
             // Flarion functions
-            FilterByFunc(_) => mapper.with_same_dtype(),
+            FilterByFunc(_, _) => mapper.with_same_dtype(),
             SortByFunc(_, _) => mapper.with_same_dtype(),
-            Transform(lambda) => mapper.map_dtype(|dt| match dt {
+            Transform(lambda, _) => mapper.map_dtype(|dt| match dt {
                 DataType::List(dt) => DataType::List(lambda.return_type(dt).unwrap().into()),
                 _ => lambda.return_type(dt).unwrap(),
             }),
@@ -188,9 +188,9 @@ impl Display for ListFunction {
             #[cfg(feature = "dtype-array")]
             ToArray(_) => "to_array",
             // Flarion functions
-            FilterByFunc(_) => "filter_by_func",
+            FilterByFunc(_, _) => "filter_by_func",
             SortByFunc(_, _) => "sort_by_func",
-            Transform(_) => "transform",
+            Transform(_, _) => "transform",
             FlarionSlice => "flarion_slice",
         };
         write!(f, "list.{name}")
@@ -254,9 +254,9 @@ impl From<ListFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             ToArray(width) => map!(to_array, width),
             NUnique => map!(n_unique),
             // Flarion functions
-            FilterByFunc(lambda) => map!(filter_by_func, lambda.clone()),
+            FilterByFunc(lambda, with_index) => map!(filter_by_func, lambda.clone(), with_index),
             SortByFunc(options, lambda) => map!(sort_by_func, options, lambda.clone()),
-            Transform(lambda) => map!(transform, lambda.clone()),
+            Transform(lambda, with_index) => map!(transform, lambda.clone(), with_index),
             FlarionSlice => wrap!(flarion_slice),
         }
     }
@@ -703,12 +703,22 @@ pub(super) fn diff(s: &Series, n: i64, null_behavior: NullBehavior) -> PolarsRes
     Ok(s.list()?.lst_diff(n, null_behavior)?.into_series())
 }
 
-pub(super) fn filter_by_func(s: &Series, lambda: Arc<LambdaExpression>) -> PolarsResult<Series> {
-    Ok(s.list()?.lst_filter_by_func(lambda)?.into_series())
+pub(super) fn filter_by_func(
+    s: &Series,
+    lambda: Arc<LambdaExpression>,
+    with_index: bool,
+) -> PolarsResult<Series> {
+    Ok(s.list()?
+        .lst_filter_by_func(lambda, with_index)?
+        .into_series())
 }
 
-pub(super) fn transform(s: &Series, lambda: Arc<LambdaExpression>) -> PolarsResult<Series> {
-    Ok(s.list()?.lst_transform(lambda)?.into_series())
+pub(super) fn transform(
+    s: &Series,
+    lambda: Arc<LambdaExpression>,
+    with_index: bool,
+) -> PolarsResult<Series> {
+    Ok(s.list()?.lst_transform(lambda, with_index)?.into_series())
 }
 
 pub(super) fn sort(s: &Series, options: SortOptions) -> PolarsResult<Series> {

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -35,6 +35,7 @@ impl ListNameSpace {
     pub fn drop_nulls(self) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::DropNulls))
+            .with_fmt("lst_drop_nulls")
     }
 
     #[cfg(feature = "list_sample")]
@@ -85,63 +86,78 @@ impl ListNameSpace {
     pub fn len(self) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Length))
+            .with_fmt("lst_len")
     }
 
     /// Compute the maximum of the items in every sublist.
     pub fn max(self) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Max))
+            .with_fmt("lst_max")
     }
 
     /// Compute the minimum of the items in every sublist.
     pub fn min(self) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Min))
+            .with_fmt("lst_min")
     }
 
     /// Compute the sum the items in every sublist.
     pub fn sum(self) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Sum))
+            .with_fmt("lst_sum")
     }
 
     /// Compute the mean of every sublist and return a `Series` of dtype `Float64`
     pub fn mean(self) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Mean))
+            .with_fmt("lst_mean")
     }
 
     pub fn median(self) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Median))
+            .with_fmt("lst_median")
     }
 
     pub fn std(self, ddof: u8) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Std(ddof)))
+            .with_fmt("lst_std")
     }
 
     pub fn var(self, ddof: u8) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Var(ddof)))
+            .with_fmt("lst_var")
     }
 
-    pub fn filter_by_func(self, func: LambdaExpression) -> Expr {
+    pub fn filter_by_func(self, func: LambdaExpression, with_index: bool) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::FilterByFunc(
                 func.into(),
+                with_index,
             )))
+            .with_fmt("lst_filter_by_func")
     }
 
-    pub fn transform(self, func: LambdaExpression) -> Expr {
+    pub fn transform(self, func: LambdaExpression, with_index: bool) -> Expr {
         self.0
-            .map_private(FunctionExpr::ListExpr(ListFunction::Transform(func.into())))
+            .map_private(FunctionExpr::ListExpr(ListFunction::Transform(
+                func.into(),
+                with_index,
+            )))
+            .with_fmt("lst_transform")
     }
 
     /// Sort every sublist.
     pub fn sort(self, options: SortOptions) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Sort(options)))
+            .with_fmt("lst_sort")
     }
 
     pub fn sort_by_func(self, options: SortOptions, func: LambdaExpression) -> Expr {
@@ -150,24 +166,28 @@ impl ListNameSpace {
                 options,
                 func.into(),
             )))
+            .with_fmt("lst_sort_by_func")
     }
 
     /// Reverse every sublist
     pub fn reverse(self) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Reverse))
+            .with_fmt("lst_rev")
     }
 
     /// Keep only the unique values in every sublist.
     pub fn unique(self) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Unique(false)))
+            .with_fmt("lst_unique")
     }
 
     /// Keep only the unique values in every sublist.
     pub fn unique_stable(self) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::Unique(true)))
+            .with_fmt("lst_stable_unique")
     }
 
     pub fn n_unique(self) -> Expr {

--- a/crates/polars-plan/src/dsl/mod.rs
+++ b/crates/polars-plan/src/dsl/mod.rs
@@ -167,6 +167,7 @@ impl Expr {
     #[allow(clippy::should_implement_trait)]
     pub fn not(self) -> Expr {
         self.map_private(BooleanFunction::Not.into())
+            .with_fmt("not")
     }
 
     /// Rename Column.
@@ -181,12 +182,14 @@ impl Expr {
     #[allow(clippy::wrong_self_convention)]
     pub fn is_null(self) -> Self {
         self.map_private(BooleanFunction::IsNull.into())
+            .with_fmt("is_null")
     }
 
     /// Run is_not_null operation on `Expr`.
     #[allow(clippy::wrong_self_convention)]
     pub fn is_not_null(self) -> Self {
         self.map_private(BooleanFunction::IsNotNull.into())
+            .with_fmt("is_not_null")
     }
 
     /// Drop null values.
@@ -756,27 +759,32 @@ impl Expr {
     #[allow(clippy::wrong_self_convention)]
     pub fn is_finite(self) -> Self {
         self.map_private(BooleanFunction::IsFinite.into())
+            .with_fmt("is_finite")
     }
 
     /// Get mask of infinite values if dtype is Float.
     #[allow(clippy::wrong_self_convention)]
     pub fn is_infinite(self) -> Self {
         self.map_private(BooleanFunction::IsInfinite.into())
+            .with_fmt("is_infinite")
     }
 
     /// Get mask of NaN values if dtype is Float.
     pub fn is_nan(self) -> Self {
         self.map_private(BooleanFunction::IsNan.into())
+            .with_fmt("is_nan")
     }
 
     /// Get inverse mask of NaN values if dtype is Float.
     pub fn is_not_nan(self) -> Self {
         self.map_private(BooleanFunction::IsNotNan.into())
+            .with_fmt("is_not_nan")
     }
 
     /// Shift the values in the array by some period. See [the eager implementation](polars_core::series::SeriesTrait::shift).
     pub fn shift(self, n: Expr) -> Self {
         self.apply_many_private(FunctionExpr::Shift, &[n], false, false)
+            .with_fmt("shift")
     }
 
     /// Shift the values in the array by some period and fill the resulting empty values.
@@ -787,6 +795,7 @@ impl Expr {
             false,
             false,
         )
+        .with_fmt("shift_and_fill")
     }
 
     /// Cumulatively count values from 0 to len.
@@ -859,12 +868,14 @@ impl Expr {
     #[cfg(feature = "round_series")]
     pub fn round(self, decimals: u32) -> Self {
         self.map_private(FunctionExpr::Round { decimals })
+            .with_fmt("round_series")
     }
 
     /// Round to a number of significant figures.
     #[cfg(feature = "round_series")]
     pub fn round_sig_figs(self, digits: i32) -> Self {
         self.map_private(FunctionExpr::RoundSF { digits })
+            .with_fmt("round_sig_figs")
     }
 
     /// Floor underlying floating point array to the lowest integers smaller or equal to the float value.

--- a/crates/polars-plan/src/dsl/name.rs
+++ b/crates/polars-plan/src/dsl/name.rs
@@ -99,6 +99,7 @@ impl ExprNameNameSpace {
             .map_private(FunctionExpr::StructExpr(StructFunction::PrefixFields(
                 PlSmallStr::from_str(prefix),
             )))
+            .with_fmt("prefix_fields")
     }
 
     #[cfg(feature = "dtype-struct")]
@@ -107,6 +108,7 @@ impl ExprNameNameSpace {
             .map_private(FunctionExpr::StructExpr(StructFunction::SuffixFields(
                 PlSmallStr::from_str(suffix),
             )))
+            .with_fmt("suffix_fields")
     }
 }
 

--- a/crates/polars-plan/src/dsl/struct_.rs
+++ b/crates/polars-plan/src/dsl/struct_.rs
@@ -14,6 +14,7 @@ impl StructNameSpace {
                 options.flags |= FunctionFlags::ALLOW_RENAME;
                 options
             })
+            .with_fmt("field_by_index")
     }
 
     /// Retrieve one or multiple of the fields of this [`StructChunked`] as a new Series.
@@ -35,6 +36,7 @@ impl StructNameSpace {
                 options.flags |= FunctionFlags::ALLOW_RENAME;
                 options
             })
+            .with_fmt("multiple_fields")
     }
 
     /// Retrieve one of the fields of this [`StructChunked`] as a new Series.
@@ -51,6 +53,7 @@ impl StructNameSpace {
                 options.flags |= FunctionFlags::ALLOW_RENAME;
                 options
             })
+            .with_fmt("field_by_name")
     }
 
     /// Rename the fields of the [`StructChunked`].
@@ -67,12 +70,14 @@ impl StructNameSpace {
             .map_private(FunctionExpr::StructExpr(StructFunction::RenameFields(
                 names,
             )))
+            .with_fmt("rename_fields")
     }
 
     #[cfg(feature = "json")]
     pub fn json_encode(self) -> Expr {
         self.0
             .map_private(FunctionExpr::StructExpr(StructFunction::JsonEncode))
+            .with_fmt("json_encode")
     }
 
     pub fn with_fields(self, fields: Vec<Expr>) -> PolarsResult<Expr> {

--- a/crates/polars-sql/tests/functions_cumulative.rs
+++ b/crates/polars-sql/tests/functions_cumulative.rs
@@ -3,11 +3,11 @@ use polars_lazy::prelude::*;
 use polars_sql::*;
 
 fn create_df() -> LazyFrame {
-    df! {
+    df! [
       "Year" => [2018, 2018, 2019, 2019, 2020, 2020],
       "Country" => ["US", "UK", "US", "UK", "US", "UK"],
       "Sales" => [1000, 2000, 3000, 4000, 5000, 6000]
-    }
+    ]
     .unwrap()
     .lazy()
 }


### PR DESCRIPTION
Also adds lots of instrumentation to polars,
We can then use this in tracy to group by zone text, so even if all the zones are "evaluate", we group by that text and get the different udf's that are actually called