### PR TITLE
fix: Sort should accept any positive/negative value as ordering

### DIFF
--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -27,10 +27,10 @@ impl TryFrom<AnyValue<'_>> for Ordering {
 
     fn try_from(value: AnyValue) -> Result<Self, Self::Error> {
         match value {
-            AnyValue::Int32(1) => Ok(Ordering::Greater),
             AnyValue::Int32(0) => Ok(Ordering::Equal),
-            AnyValue::Int32(-1) => Ok(Ordering::Less),
-            other => polars_bail!(InvalidOperation: "Expected -1, 0, or 1, found {:?}", other),
+            AnyValue::Int32(v) if v.is_positive() => Ok(Ordering::Greater),
+            AnyValue::Int32(v) if v.is_negative() => Ok(Ordering::Less),
+            _ => unreachable!("Expected int32 value"),
         }
     }
 }
@@ -224,22 +224,46 @@ impl LambdaExpression {
             LambdaExpression::GreaterThan(left, right) => {
                 let left = left.eval_window(curr, next)?;
                 let right = right.eval_window(curr, next)?;
-                Ok(AnyValue::Boolean(left.gt(&right)))
+
+                // Override the comparison function for array_sort
+                match (left.is_null(), right.is_null()) {
+                    (true, false) => Ok(AnyValue::Boolean(true)),
+                    (false, true) => Ok(AnyValue::Boolean(false)),
+                    _ => Ok(AnyValue::Boolean(left.gt(&right))),
+                }
             },
             LambdaExpression::GreaterThanOrEqual(left, right) => {
                 let left = left.eval_window(curr, next)?;
                 let right = right.eval_window(curr, next)?;
-                Ok(AnyValue::Boolean(left.ge(&right)))
+
+                // Override the comparison function for array_sort
+                match (left.is_null(), right.is_null()) {
+                    (true, false) => Ok(AnyValue::Boolean(true)),
+                    (false, true) => Ok(AnyValue::Boolean(false)),
+                    _ => Ok(AnyValue::Boolean(left.ge(&right))),
+                }
             },
             LambdaExpression::LessThan(left, right) => {
                 let left = left.eval_window(curr, next)?;
                 let right = right.eval_window(curr, next)?;
-                Ok(AnyValue::Boolean(left.lt(&right)))
+
+                // Override the comparison function for array_sort
+                match (left.is_null(), right.is_null()) {
+                    (true, false) => Ok(AnyValue::Boolean(false)),
+                    (false, true) => Ok(AnyValue::Boolean(true)),
+                    _ => Ok(AnyValue::Boolean(left.lt(&right))),
+                }
             },
             LambdaExpression::LessThanOrEqual(left, right) => {
                 let left = left.eval_window(curr, next)?;
                 let right = right.eval_window(curr, next)?;
-                Ok(AnyValue::Boolean(left.le(&right)))
+
+                // Override the comparison function for array_sort
+                match (left.is_null(), right.is_null()) {
+                    (true, false) => Ok(AnyValue::Boolean(false)),
+                    (false, true) => Ok(AnyValue::Boolean(true)),
+                    _ => Ok(AnyValue::Boolean(left.le(&right))),
+                }
             },
             #[cfg(feature = "zip_with")]
             LambdaExpression::IfThenElse(pred, value, otherwise) => {

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -1,8 +1,7 @@
 use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
-use std::ops::Add;
-use std::ops::BitAnd;
+use std::ops::{Add, BitAnd};
 use std::{iter, mem};
 
 use num_traits::ToBytes;
@@ -382,10 +381,14 @@ impl LambdaExpression {
                 let left = left.eval_window(curr, next)?;
                 let right = right.eval_window(curr, next)?;
                 match (left, right) {
-                    (AnyValue::Boolean(left), AnyValue::Boolean(right)) => Ok(AnyValue::Boolean(left && right)),
-                    (left, right) => polars_bail!(SchemaMismatch: "Expected (boolean, boolean), found ({}, {})", left, right),
+                    (AnyValue::Boolean(left), AnyValue::Boolean(right)) => {
+                        Ok(AnyValue::Boolean(left && right))
+                    },
+                    (left, right) => {
+                        polars_bail!(SchemaMismatch: "Expected (boolean, boolean), found ({}, {})", left, right)
+                    },
                 }
-            }
+            },
         }
     }
 
@@ -550,7 +553,7 @@ impl LambdaExpression {
                 let left = left.eval(s, i)?;
                 let right = right.eval(s, i)?;
                 Ok(left.bool()?.bitand(right.bool()?).into_series())
-            }
+            },
         }
     }
 

--- a/crates/polars-core/src/chunked_array/ops/lambda.rs
+++ b/crates/polars-core/src/chunked_array/ops/lambda.rs
@@ -2,6 +2,7 @@ use std::borrow::Cow;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
 use std::ops::Add;
+use std::ops::BitAnd;
 use std::{iter, mem};
 
 use num_traits::ToBytes;
@@ -67,6 +68,7 @@ pub enum LambdaExpression {
     IsNotNull(Box<Self>),
     EqualNullSafe(Box<Self>, Box<Self>),
     Cast(Box<Self>, DataType),
+    And(Box<Self>, Box<Self>),
 }
 
 impl Eq for LambdaExpression {}
@@ -139,6 +141,10 @@ impl Hash for LambdaExpression {
                 v.hash(state);
                 data_type.hash(state);
             },
+            LambdaExpression::And(first, second) => {
+                first.hash(state);
+                second.hash(state);
+            },
         }
     }
 }
@@ -176,6 +182,7 @@ impl LambdaExpression {
             LambdaExpression::IsNotNull(_) => "is_not_null",
             LambdaExpression::EqualNullSafe(_, _) => "equal_null_safe",
             LambdaExpression::Cast(_, _) => "cast",
+            LambdaExpression::And(_, _) => "and",
         }
     }
 
@@ -371,6 +378,14 @@ impl LambdaExpression {
                 let s = child.eval_window(curr, next)?;
                 Ok(s.cast(dtype).to_owned())
             },
+            LambdaExpression::And(left, right) => {
+                let left = left.eval_window(curr, next)?;
+                let right = right.eval_window(curr, next)?;
+                match (left, right) {
+                    (AnyValue::Boolean(left), AnyValue::Boolean(right)) => Ok(AnyValue::Boolean(left && right)),
+                    (left, right) => polars_bail!(SchemaMismatch: "Expected (boolean, boolean), found ({}, {})", left, right),
+                }
+            }
         }
     }
 
@@ -531,6 +546,11 @@ impl LambdaExpression {
                 let s = child.eval(s, i)?;
                 s.cast_with_options(dtype, CastOptions::Overflowing)
             },
+            LambdaExpression::And(left, right) => {
+                let left = left.eval(s, i)?;
+                let right = right.eval(s, i)?;
+                Ok(left.bool()?.bitand(right.bool()?).into_series())
+            }
         }
     }
 
@@ -582,6 +602,7 @@ impl LambdaExpression {
             LambdaExpression::IsNotNull(_) => DataType::Boolean,
             LambdaExpression::EqualNullSafe(_, _) => DataType::Boolean,
             LambdaExpression::Cast(_, data_type) => data_type.clone(),
+            LambdaExpression::And(_, _) => DataType::Boolean,
         })
     }
 }

--- a/crates/polars-ops/src/chunked_array/list/namespace.rs
+++ b/crates/polars-ops/src/chunked_array/list/namespace.rs
@@ -360,7 +360,6 @@ pub trait ListNameSpaceImpl: AsList {
 
     fn lst_sort_by_func(
         &self,
-        _options: SortOptions,
         lambda_expressions: Arc<LambdaExpression>,
     ) -> PolarsResult<ListChunked> {
         let ca = self.as_list();
@@ -988,7 +987,7 @@ fn cast_index(idx: Series, len: usize, null_on_oob: bool) -> PolarsResult<Series
 // Was using these to debug but I see no harm in having more unit tests, in fact we should probably have more here
 #[cfg(test)]
 mod tests {
-    use polars_core::prelude::{IntoSeries, LambdaExpression, ListChunked, Series, SortOptions};
+    use polars_core::prelude::{IntoSeries, LambdaExpression, ListChunked, Series};
 
     use crate::chunked_array::ListNameSpaceImpl;
 
@@ -1165,10 +1164,7 @@ mod tests {
         let result = start_array
             .list()
             .unwrap()
-            .lst_sort_by_func(
-                SortOptions::new().with_nulls_last(true),
-                ascending_lambda.into(),
-            )
+            .lst_sort_by_func(ascending_lambda.into())
             .expect("Could not evaluate lambda");
         let res = result.get_as_series(0).unwrap();
 

--- a/crates/polars-plan/src/dsl/function_expr/list.rs
+++ b/crates/polars-plan/src/dsl/function_expr/list.rs
@@ -58,7 +58,7 @@ pub enum ListFunction {
     ToArray(usize),
     // Flarion functions
     FilterByFunc(Arc<LambdaExpression>, bool),
-    SortByFunc(SortOptions, Arc<LambdaExpression>),
+    SortByFunc(Arc<LambdaExpression>),
     Transform(Arc<LambdaExpression>, bool),
     FlarionSlice,
 }
@@ -110,7 +110,7 @@ impl ListFunction {
             NUnique => mapper.with_dtype(IDX_DTYPE),
             // Flarion functions
             FilterByFunc(_, _) => mapper.with_same_dtype(),
-            SortByFunc(_, _) => mapper.with_same_dtype(),
+            SortByFunc(_) => mapper.with_same_dtype(),
             Transform(lambda, _) => mapper.map_dtype(|dt| match dt {
                 DataType::List(dt) => DataType::List(lambda.return_type(dt).unwrap().into()),
                 _ => lambda.return_type(dt).unwrap(),
@@ -189,7 +189,7 @@ impl Display for ListFunction {
             ToArray(_) => "to_array",
             // Flarion functions
             FilterByFunc(_, _) => "filter_by_func",
-            SortByFunc(_, _) => "sort_by_func",
+            SortByFunc(_) => "sort_by_func",
             Transform(_, _) => "transform",
             FlarionSlice => "flarion_slice",
         };
@@ -255,7 +255,7 @@ impl From<ListFunction> for SpecialEq<Arc<dyn SeriesUdf>> {
             NUnique => map!(n_unique),
             // Flarion functions
             FilterByFunc(lambda, with_index) => map!(filter_by_func, lambda.clone(), with_index),
-            SortByFunc(options, lambda) => map!(sort_by_func, options, lambda.clone()),
+            SortByFunc(lambda) => map!(sort_by_func, lambda.clone()),
             Transform(lambda, with_index) => map!(transform, lambda.clone(), with_index),
             FlarionSlice => wrap!(flarion_slice),
         }
@@ -725,12 +725,8 @@ pub(super) fn sort(s: &Series, options: SortOptions) -> PolarsResult<Series> {
     Ok(s.list()?.lst_sort(options)?.into_series())
 }
 
-pub(super) fn sort_by_func(
-    s: &Series,
-    options: SortOptions,
-    lambda: Arc<LambdaExpression>,
-) -> PolarsResult<Series> {
-    Ok(s.list()?.lst_sort_by_func(options, lambda)?.into_series())
+pub(super) fn sort_by_func(s: &Series, lambda: Arc<LambdaExpression>) -> PolarsResult<Series> {
+    Ok(s.list()?.lst_sort_by_func(lambda)?.into_series())
 }
 
 pub(super) fn reverse(s: &Series) -> PolarsResult<Series> {

--- a/crates/polars-plan/src/dsl/list.rs
+++ b/crates/polars-plan/src/dsl/list.rs
@@ -160,10 +160,9 @@ impl ListNameSpace {
             .with_fmt("lst_sort")
     }
 
-    pub fn sort_by_func(self, options: SortOptions, func: LambdaExpression) -> Expr {
+    pub fn sort_by_func(self, func: LambdaExpression) -> Expr {
         self.0
             .map_private(FunctionExpr::ListExpr(ListFunction::SortByFunc(
-                options,
                 func.into(),
             )))
             .with_fmt("lst_sort_by_func")


### PR DESCRIPTION
feat: And lambda expression
fix: Explicitly override polars cmp for nulls in eval_window
chore: Remove unneeded SortOptions in lst_sort_by_func